### PR TITLE
conan: Enable separate dynamoDB for DEV

### DIFF
--- a/conan/conan-dev.rc
+++ b/conan/conan-dev.rc
@@ -1,5 +1,6 @@
 export threads=2
-export aws_profile=pool-manager-dev
+export aws_profile=pool-manager
+export dynamodb_profile=pool-manager-dev
 export dynamodb_table=accounts-dev
 export dynamodb_region=us-east-1
 export aws_nuke_binary_path=/bin/true

--- a/conan/conan-dev.service
+++ b/conan/conan-dev.service
@@ -5,11 +5,14 @@ Documentation=https://github.com/rhpds/sandbox/tree/main/conan
 
 [Service]
 Environment=threads=2
-Environment=aws_profile=pool-manager-dev
+Environment=conan_instance=conan-dev1
+Environment=aws_profile=pool-manager
+Environment=dynamodb_profile=pool-manager-dev
 Environment=dynamodb_table=accounts-dev
 Environment=dynamodb_region=us-east-1
-Environment=aws_nuke_binary_path=/bin/true
-Environment=noop=true
+# Uncomment the following to enable noop mode
+#Environment=aws_nuke_binary_path=/bin/true
+#Environment=noop=true
 
 User=opentlc-mgr
 Group=opentlc-mgr

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -13,6 +13,7 @@ threads="${threads:-12}"
 aws_profile="${aws_profile:-pool-manager}"
 
 # DynamoDB
+dynamodb_profile="${dynamodb_profile:-pool-manager}"
 dynamodb_table="${dynamodb_table:-accounts}"
 dynamodb_region="${dynamodb_region:-us-east-1}"
 
@@ -28,6 +29,8 @@ noop=${noop:-false}
 # python virtualenv
 VENV=${VENV:-~/pool_management/python_virtualenv}
 
+# Conan instance: the name of the host running the cleanup
+conan_instance=${conan_instance:-$(hostname)}
 
 # Lock timeout:  the number of hours after which a lock on a sandbox expires.
 # For ex: '2': a conan process will have 2h to cleanup the sandbox before another
@@ -40,6 +43,7 @@ lock_timeout=${lock_timeout:-2}
 
 export threads
 export aws_profile
+export dynamodb_profile
 export dynamodb_table
 export dynamodb_region
 export poll_interval
@@ -47,6 +51,7 @@ export aws_nuke_binary_path
 export noop
 export VENV
 export lock_timeout
+export conan_instance
 
 ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 
@@ -77,7 +82,7 @@ pre_checks() {
             exit 5
         fi
     done
-    if ! AWS_PROFILE=${aws_profile} \
+    if ! AWS_PROFILE=${dynamodb_profile} \
         AWS_REGION=${dynamodb_region} \
         dynamodb_table=${dynamodb_table} \
         sandbox-list --to-cleanup --no-headers &> /dev/null
@@ -89,6 +94,7 @@ pre_checks() {
 }
 
 echo "AWS profile: ${aws_profile}"
+echo "DynamoDB profile: ${dynamodb_profile}"
 echo "DynamoDB table: ${dynamodb_table}"
 
 pre_checks
@@ -99,7 +105,7 @@ cd "${ORIG}"
 while true; do
 
     (
-        export AWS_PROFILE=${aws_profile}
+        export AWS_PROFILE=${dynamodb_profile}
         export AWS_REGION=${dynamodb_region}
         export dynamodb_table=${dynamodb_table}
         sandbox-list --to-cleanup --no-headers

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -9,6 +9,7 @@ TTL_EVENTLOG=$((3600*24))
 
 
 # Mandatory ENV variables
+: "${dynamodb_profile:?"dynamodb_profile is unset or null"}"
 : "${dynamodb_table:?"dynamodb_table is unset or null"}"
 : "${dynamodb_region:?"dynamodb_region is unset or null"}"
 : "${noop:?"noop is unset or empty"}"
@@ -38,7 +39,7 @@ sandbox_unlock() {
   }
 EOM
 
-    "$VENV/bin/aws" --profile "${aws_profile}" \
+    "$VENV/bin/aws" --profile "${dynamodb_profile}" \
         --region "${dynamodb_region}" \
         dynamodb update-item \
         --table-name "${dynamodb_table}" \
@@ -55,19 +56,20 @@ _on_exit() {
 
 sandbox_lock() {
     local sandbox=$1
+    conan_instance=${conan_instance:-$(hostname)}
     read -r -d '' data << EOM
   {
         ":av": {"BOOL": false},
         ":st": {"S": "cleanup in progress"},
         ":timestamp": {"S": "$(date -uIs)"},
         ":old": {"S": "$(date -uIs -d "now - ${lock_timeout} hour")"},
-        ":host": {"S": "$(hostname)"}
+        ":host": {"S": "${conan_instance}"}
   }
 EOM
 
     errlog=$(mktemp)
 
-    if ! "$VENV/bin/aws" --profile "${aws_profile}" \
+    if ! "$VENV/bin/aws" --profile "${dynamodb_profile}" \
         --region "${dynamodb_region}" \
         dynamodb update-item \
         --table-name "${dynamodb_table}" \
@@ -138,6 +140,7 @@ sandbox_reset() {
     "${VENV}/bin/ansible-playbook" -i localhost, \
                      -e _account_num="${s}" \
                      -e aws_master_profile="${aws_profile}" \
+                     -e dynamodb_profile="${dynamodb_profile}" \
                      -e dynamodb_table="${dynamodb_table}" \
                      -e dynamodb_region="${dynamodb_region}" \
                      -e aws_nuke_binary_path="${aws_nuke_binary_path}" \

--- a/playbooks/roles/infra-aws-sandbox/defaults/main.yml
+++ b/playbooks/roles/infra-aws-sandbox/defaults/main.yml
@@ -138,6 +138,7 @@ aws_nuke_filters_default:
 # POOL management
 ##############################
 
+dynamodb_profile: "{{ aws_master_profile }}"
 dynamodb_table: accounts
 dynamodb_region: us-east-1
 

--- a/playbooks/roles/infra-aws-sandbox/tasks/account.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/account.yml
@@ -5,7 +5,7 @@
       name:
         S: "{{ account_name }}"
   command: >-
-    aws --profile {{ aws_master_profile }}
+    aws --profile {{ dynamodb_profile }}
     --region {{ dynamodb_region }}
     dynamodb get-item
     --table-name {{ dynamodb_table }}

--- a/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/pool.yml
@@ -5,7 +5,7 @@
       name:
         S: "{{ account_name }}"
   command: >-
-    aws --profile {{ aws_master_profile }} --region {{ dynamodb_region }}
+    aws --profile {{ dynamodb_profile }} --region {{ dynamodb_region }}
     dynamodb get-item
     --table-name {{ dynamodb_table }}
     --key '{{ _data | to_json }}'
@@ -32,7 +32,7 @@
       zone:
         S: "{{ account_name }}{{subdomain_base}}"
   command: >-
-    aws --profile {{ aws_master_profile }} --region {{ dynamodb_region }}
+    aws --profile {{ dynamodb_profile }} --region {{ dynamodb_region }}
     dynamodb put-item
     --table-name {{ dynamodb_table }}
     --item '{{ _data | to_json }}'
@@ -62,7 +62,7 @@
           zone:
             S: "{{ account_name }}{{subdomain_base}}"
       command: >-
-        aws --profile {{ aws_master_profile }}
+        aws --profile {{ dynamodb_profile }}
         --region {{ dynamodb_region }}
         dynamodb put-item
         --table-name {{ dynamodb_table }}
@@ -89,7 +89,7 @@
           zone:
             S: "{{ account_name }}{{subdomain_base}}"
       command: >-
-        aws --profile {{ aws_master_profile }}
+        aws --profile {{ dynamodb_profile }}
         --region {{ dynamodb_region }}
         dynamodb put-item
         --table-name {{ dynamodb_table }}

--- a/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/validate.yaml
@@ -8,7 +8,7 @@
       name:
         S: "{{ account_name }}"
   command: >-
-    aws --profile {{ aws_master_profile }} --region {{ dynamodb_region }}
+    aws --profile {{ dynamodb_profile }} --region {{ dynamodb_region }}
     dynamodb get-item
     --table-name {{ dynamodb_table }}
     --key '{{ _data | to_json }}'


### PR DESCRIPTION
`GPTEINFRA-6621`
To be able to cleanup the dev database, we need to pass the AWS profile to use for any dynamodb communication.

This change, if appliced, introduce a new environment variable 'dynamodb_profile' to be able to specify the AWS profile to use.

By default, it's the same as the AWS profile to manage all the accounts and to assume role inside the accounts (prod).

For DEV, a different AWS account will be passed, as the DB is in a different AWS account.

Also add a variable for the name of the instance.

Update the conan-dev.service systemd service unit.