### PR TITLE
Create lifecycle handler for placements

### DIFF
--- a/cmd/sandbox-api/account_handlers.go
+++ b/cmd/sandbox-api/account_handlers.go
@@ -31,15 +31,15 @@ func (h *AccountHandler) GetAccountsHandler(w http.ResponseWriter, r *http.Reque
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", " ")
 
-	serviceUuuid := r.URL.Query().Get("service_uuid")
+	serviceUuid := r.URL.Query().Get("service_uuid")
 
 	var (
 		accounts []models.AwsAccount
 		err      error
 	)
-	if serviceUuuid != "" {
+	if serviceUuid != "" {
 		// Get the account from DynamoDB
-		accounts, err = h.accountProvider.FetchAllByServiceUuid(serviceUuuid)
+		accounts, err = h.accountProvider.FetchAllByServiceUuid(serviceUuid)
 
 	} else {
 		accounts, err = h.accountProvider.FetchAll()
@@ -277,13 +277,14 @@ func (h *BaseHandler) GetStatusAccountHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	status := models.MakeStatus(job)
+
 	// Print account using JSON
 	w.WriteHeader(http.StatusOK)
 	log.Logger.Debug("GET account status", "status", job.Result, "updated_at", job.UpdatedAt)
 	err = render.Render(w, r, &v1.AccountStatusResponse{
 		HTTPStatusCode: http.StatusOK,
-		Status:         job.Result,
-		UpdatedAt:      job.UpdatedAt,
+		Status:         status,
 	})
 
 	if err != nil {

--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -192,6 +192,10 @@ func main() {
 		r.Post("/api/v1/placements", baseHandler.CreatePlacementHandler)
 		r.Get("/api/v1/placements/{uuid}", baseHandler.GetPlacementHandler)
 		r.Delete("/api/v1/placements/{uuid}", baseHandler.DeletePlacementHandler)
+		r.Put("/api/v1/placements/{uuid}/stop", baseHandler.LifeCyclePlacementHandler("stop"))
+		r.Put("/api/v1/placements/{uuid}/start", baseHandler.LifeCyclePlacementHandler("start"))
+		r.Put("/api/v1/placements/{uuid}/status", baseHandler.LifeCyclePlacementHandler("status"))
+		r.Get("/api/v1/placements/{uuid}/status", baseHandler.GetStatusPlacementHandler)
 	})
 
 	// ---------------------------------------------------------------------

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -226,6 +226,164 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /placements/{uuid}/stop:
+    parameters:
+      - in: header
+        name: Authorization
+        description: Access JTW Token
+        required: true
+        schema:
+          type: string
+          example: Bearer <ACCESS_TOKEN>
+      - name: uuid
+        in: path
+        required: true
+        description: The UUID of the service.
+        schema:
+          $ref: "#/components/schemas/UUID"
+    put:
+      tags:
+        - placement
+      operationId: stopPlacement
+      summary: Stop all the resources of a placement assigned to a specific UUID.
+      description: |-
+        Call this endpoint to stop all the resources in all the accounts of a service identified by service UUID.
+
+        This action will cascade stop to all the accounts associated with the placement.
+      responses:
+        '200':
+          description: The stop request was created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LifecycleResponse"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: stopPlacement unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /placements/{uuid}/start:
+    parameters:
+      - in: header
+        name: Authorization
+        description: Access JTW Token
+        required: true
+        schema:
+          type: string
+          example: Bearer <ACCESS_TOKEN>
+      - name: uuid
+        in: path
+        required: true
+        description: The UUID of the service.
+        schema:
+          $ref: "#/components/schemas/UUID"
+    put:
+      tags:
+        - placement
+      operationId: startPlacement
+      summary: Start all the resources of a placement assigned to a specific UUID.
+      description: |-
+        Call this endpoint to start all the resources in all the accounts of a service identified by service UUID.
+
+        This action will cascade start to all the accounts associated with the placement.
+      responses:
+        '200':
+          description: The start request was created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LifecycleResponse"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: startPlacement unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /placements/{uuid}/status:
+    parameters:
+      - in: header
+        name: Authorization
+        description: Access JTW Token
+        required: true
+        schema:
+          type: string
+          example: Bearer <ACCESS_TOKEN>
+      - name: uuid
+        in: path
+        required: true
+        description: The UUID of the service.
+        schema:
+          $ref: "#/components/schemas/UUID"
+    put:
+      tags:
+        - placement
+      operationId: statusPlacement
+      summary: Request new status update of all accounts of a placement
+      description: |-
+        Given a placement, query an async status on all its resources
+      responses:
+        '200':
+          description: The status request was created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LifecycleResponse"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: statusAccount unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    get:
+      tags:
+        - placement
+      operationId: getStatusPlacement
+      summary: Get latest status of all accounts in an placement
+      description: |-
+        Given a specific placement, return the latest status.
+
+        To trigger a new asynchronous status update, use the PUT method.
+      responses:
+        '200':
+          description: Placement status
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AccountStatus"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: getStatusPlacement unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /accounts/{kind}:
     parameters:
@@ -374,6 +532,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /accounts/{kind}/{name}/stop:
     parameters:
       - in: header

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -64,10 +64,17 @@ type LifecycleRequestResponse struct {
 type AccountStatusResponse struct {
 	HTTPStatusCode int           `json:"http_code,omitempty"` // http response status code
 	Status         models.Status `json:"status,omitempty"`
-	UpdatedAt      time.Time     `json:"updated_at,omitempty"`
+}
+
+type PlacementStatusResponse struct {
+	HTTPStatusCode int             `json:"http_code,omitempty"` // http response status code
+	Status         []models.Status `json:"status,omitempty"`
 }
 
 func (p *AccountStatusResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+func (p *PlacementStatusResponse) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -148,7 +148,6 @@ func makeAccount(account AwsAccountDynamoDB) models.AwsAccount {
 	return a
 }
 
-
 // makeAccounts creates new []models.AwsAccount from []AwsAccountDynamoDB
 func makeAccounts(accounts []AwsAccountDynamoDB) []models.AwsAccount {
 	r := []models.AwsAccount{}
@@ -158,6 +157,7 @@ func makeAccounts(accounts []AwsAccountDynamoDB) []models.AwsAccount {
 
 	return r
 }
+
 // makeAccountWithCreds creates new models.AwsAccountWithCreds from AwsAccountDynamoDB
 func (provider *AwsAccountDynamoDBProvider) makeAccountWithCreds(account AwsAccountDynamoDB) models.AwsAccountWithCreds {
 

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -276,7 +276,23 @@ type Instance struct {
 
 // Status type
 type Status struct {
-	Instances []Instance `json:"instances"`
+	AccountName string     `json:"account_name"`
+	AccountKind string     `json:"account_kind"`
+	Instances   []Instance `json:"instances"`
+	UpdatedAt   time.Time  `json:"updated_at,omitempty"`
+	Status      string     `json:"status,omitempty"`
+}
+
+func MakeStatus(job *LifecycleResourceJob) Status {
+	var status Status
+
+	status = job.Result
+	status.AccountKind = job.ResourceType
+	status.AccountName = job.ResourceName
+	status.UpdatedAt = job.UpdatedAt
+	status.Status = job.Status
+
+	return status
 }
 
 // Status method returns the status of all the instances in the account
@@ -343,6 +359,8 @@ func (a AwsAccount) Status(creds *ststypes.Credentials, job *LifecycleResourceJo
 	}
 
 	status.Instances = instances
+	status.AccountName = a.Name
+	status.AccountKind = a.Kind
 
 	// save status as json
 	_, err = job.DbPool.Exec(

--- a/internal/models/lifecycle_jobs.go
+++ b/internal/models/lifecycle_jobs.go
@@ -40,9 +40,9 @@ func GetLifecycleResourceJob(dbpool *pgxpool.Pool, id int) (*LifecycleResourceJo
 
 	err := dbpool.QueryRow(
 		context.Background(),
-		"SELECT id, COALESCE(parent_id, 0), resource_name, resource_type, status, request, lifecycle_result, lifecycle_action FROM lifecycle_resource_jobs WHERE id = $1",
+		"SELECT id, COALESCE(parent_id, 0), resource_name, resource_type, status, request, lifecycle_result, lifecycle_action, updated_at FROM lifecycle_resource_jobs WHERE id = $1",
 		id,
-	).Scan(&j.ID, &j.ParentID, &j.ResourceName, &j.ResourceType, &j.Status, &j.Request, &j.Result, &j.Action)
+	).Scan(&j.ID, &j.ParentID, &j.ResourceName, &j.ResourceType, &j.Status, &j.Request, &j.Result, &j.Action, &j.UpdatedAt)
 
 	if err != nil {
 		return nil, err
@@ -135,6 +135,26 @@ func (j *LifecycleResourceJob) Create() error {
 		return err
 	}
 
+	return nil
+}
+
+// Create creates a new LifecyclePlacementJob by inserting it into the database
+func (j *LifecyclePlacementJob) Create() error {
+	err := j.DbPool.QueryRow(
+		context.Background(),
+		`INSERT INTO lifecycle_placement_jobs
+		(placement_id, status, request, request_id, lifecycle_action)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		j.PlacementID,
+		j.Status,
+		j.Request,
+		j.RequestID,
+		j.Action,
+	).Scan(&j.ID)
+
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/todo.org
+++ b/todo.org
@@ -42,7 +42,7 @@
 ** DONE GET /admin/jwt   to list login tokens
 * DONE create OCI image
 * DONE create helm chart
-* TODO lifecycle worker pool
+* DONE lifecycle worker pool
 ** DONE publish/subscribe channels
 ** DONE dispatcher listener worker
 ** DONE define AWS credential (root account) to manage the sandbox lifecycle -- use the same as dynamodb access
@@ -50,7 +50,9 @@
 ** DONE create lifecycle handler for accounts
 ** DONE create golang channel for stop/start
 ** DONE parameterize the number of concurrent workers
-** TODO create lifecycle handler for placements
+** DONE create lifecycle handler for placements
+*** TODO test legacy placement/stop/start/status
+*** TODO proper lifecyclePlacementResponse with examples
 * DONE OpenShift limit and req for pods
 * TODO patch clients (sandbox-list, mark_for_cleanup script, etc) to use the sandbox-API instead of dynamodb
 * TODO unit tests and fixture/functional tests
@@ -61,3 +63,4 @@
 ** TODO aws lambda function to replicate changes from dynamoDB to postgresql
 ** TODO add POST /refresh   to get new access token
 ** TODO rename env variable:  prefix with DYNAMODB_ for anything related to dynamodb access
+

--- a/todo.org
+++ b/todo.org
@@ -51,8 +51,8 @@
 ** DONE create golang channel for stop/start
 ** DONE parameterize the number of concurrent workers
 ** DONE create lifecycle handler for placements
-*** TODO test legacy placement/stop/start/status
-*** TODO proper lifecyclePlacementResponse with examples
+*** DONE test legacy placement/stop/start/status
+*** DONE proper lifecyclePlacementResponse with examples
 * DONE OpenShift limit and req for pods
 * TODO patch clients (sandbox-list, mark_for_cleanup script, etc) to use the sandbox-API instead of dynamodb
 * TODO unit tests and fixture/functional tests


### PR DESCRIPTION
Placements can have several resources like aws accounts. Create the handlers to execute start or stop action directly on a placement rather than the accounts directly.

The sandbox-api cascades the actions to the accounts associated with the placement.

- Update swagger file