### PR TITLE
Add http endpoints to get status for requets

### DIFF
--- a/cmd/sandbox-api/account_handlers.go
+++ b/cmd/sandbox-api/account_handlers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rhpds/sandbox/internal/models"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 )
 
@@ -171,7 +170,7 @@ func (h *BaseHandler) LifeCycleAccountHandler(action string) http.HandlerFunc {
 		// by the swagger openAPI spec.
 		// kind := chi.URLParam(r, "kind")
 
-		reqId := middleware.GetReqID(r.Context())
+		reqId := GetReqID(r.Context())
 
 		// Get the account from DynamoDB
 		sandbox, err := h.accountProvider.FetchByName(accountName)

--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -159,7 +159,7 @@ func main() {
 	// Middlewares
 	// ---------------------------------------------------------------------
 	router.Use(middleware.CleanPath)
-	router.Use(middleware.RequestID)
+	router.Use(ShortRequestID)
 	router.Use(httplog.RequestLogger(logger))
 	router.Use(middleware.Heartbeat("/ping"))
 	// Set Content-Type header to application/json for all responses
@@ -196,6 +196,7 @@ func main() {
 		r.Put("/api/v1/placements/{uuid}/start", baseHandler.LifeCyclePlacementHandler("start"))
 		r.Put("/api/v1/placements/{uuid}/status", baseHandler.LifeCyclePlacementHandler("status"))
 		r.Get("/api/v1/placements/{uuid}/status", baseHandler.GetStatusPlacementHandler)
+		r.Get("/api/v1/requests/{id}/status", baseHandler.GetStatusRequestHandler)
 	})
 
 	// ---------------------------------------------------------------------

--- a/cmd/sandbox-api/middlewares.go
+++ b/cmd/sandbox-api/middlewares.go
@@ -258,6 +258,7 @@ func AuthenticatorAccess(next http.Handler) http.Handler {
 // RequestID
 
 var RequestIDHeader = "X-Request-Id"
+
 // Key to use when setting the request ID.
 type ctxKeyRequestID int
 

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -743,13 +743,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/LifecycleResponse"
         '404':
-          description: Account not found
+          description: Request not found
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
         default:
-          description: getStatusAccount unexpected error
+          description: getStatusRequest unexpected error
           content:
             application/json:
               schema:

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -713,6 +713,47 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /requests/{id}/status:
+    parameters:
+      - in: header
+        name: Authorization
+        description: Access JTW Token
+        required: true
+        schema:
+          type: string
+          example: Bearer <ACCESS_TOKEN>
+      - name: id
+        in: path
+        required: true
+        description: The id of the request
+        schema:
+          type: string
+    get:
+      tags:
+        - requests
+      operationId: getStatusRequest
+      summary: Get status of a request
+      description: |-
+        Returns status of a request.
+      responses:
+        '200':
+          description: Request status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LifecycleResponse"
+        '404':
+          description: Account not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: getStatusAccount unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /admin/jwt:
     parameters:
       - in: header
@@ -1193,10 +1234,13 @@ components:
       properties:
         request_id:
           type: string
-          example: hostname/icXUKzyr5U-000002
+          example: F8HWO8Bo79n1I_DPQPIEw
         message:
           type: string
           example: "Request created"
+        status:
+          type: string
+          example: "running"
     AccountStatus:
       type: object
       properties:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-chi/render v1.0.2
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/lestrrat-go/jwx/v2 v2.0.9
+	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/prometheus/client_golang v1.15.0
 	github.com/sosedoff/ansible-vault-go v0.2.0
 	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,9 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matoous/go-nanoid v1.5.0/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
+github.com/matoous/go-nanoid/v2 v2.0.0 h1:d19kur2QuLeHmJBkvYkFdhFBzLoo1XVm2GgTpL+9Tj0=
+github.com/matoous/go-nanoid/v2 v2.0.0/go.mod h1:FtS4aGPVfEkxKxhdWPAspZpZSh1cOjtM7Ej/So3hR0g=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -59,6 +59,7 @@ type LifecycleRequestResponse struct {
 	HTTPStatusCode int    `json:"http_code,omitempty"` // http response status code
 	Message        string `json:"message"`
 	RequestID      string `json:"request_id,omitempty"`
+	Status		   string `json:"status,omitempty"`
 }
 
 type AccountStatusResponse struct {

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -59,7 +59,7 @@ type LifecycleRequestResponse struct {
 	HTTPStatusCode int    `json:"http_code,omitempty"` // http response status code
 	Message        string `json:"message"`
 	RequestID      string `json:"request_id,omitempty"`
-	Status		   string `json:"status,omitempty"`
+	Status         string `json:"status,omitempty"`
 }
 
 type AccountStatusResponse struct {

--- a/internal/models/lifecycle_jobs.go
+++ b/internal/models/lifecycle_jobs.go
@@ -53,6 +53,24 @@ func GetLifecycleResourceJob(dbpool *pgxpool.Pool, id int) (*LifecycleResourceJo
 	return &j, nil
 }
 
+func GetLifecycleResourceJobByRequestID(dbpool *pgxpool.Pool, requestID string) (*LifecycleResourceJob, error) {
+	var j LifecycleResourceJob
+
+	err := dbpool.QueryRow(
+		context.Background(),
+		"SELECT id, COALESCE(parent_id, 0), resource_name, resource_type, status, request, lifecycle_result, lifecycle_action, updated_at FROM lifecycle_resource_jobs WHERE request_id = $1",
+		requestID,
+	).Scan(&j.ID, &j.ParentID, &j.ResourceName, &j.ResourceType, &j.Status, &j.Request, &j.Result, &j.Action, &j.UpdatedAt)
+
+	if err != nil {
+		return nil, err
+	}
+
+	j.DbPool = dbpool
+
+	return &j, nil
+}
+
 // GetLifecyclePlacementJob returns a LifecyclePlacementJob by ID
 func GetLifecyclePlacementJob(dbpool *pgxpool.Pool, id int) (*LifecyclePlacementJob, error) {
 	var j LifecyclePlacementJob
@@ -61,6 +79,30 @@ func GetLifecyclePlacementJob(dbpool *pgxpool.Pool, id int) (*LifecyclePlacement
 		context.Background(),
 		"SELECT id, placement_id, status, request, lifecycle_action FROM lifecycle_placement_jobs WHERE id = $1",
 		id,
+	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.Request, &j.Action)
+	if err != nil {
+		return nil, err
+	}
+
+	j.DbPool = dbpool
+
+	return &j, nil
+}
+
+// GetLifecyclePlacementJob returns a LifecyclePlacementJob by ID
+func GetLifecyclePlacementJobByRequestID(dbpool *pgxpool.Pool, requestID string) (*LifecyclePlacementJob, error) {
+	var j LifecyclePlacementJob
+
+	log.Logger.Info("sql",
+		"sql",
+		"SELECT id, placement_id, status, request, lifecycle_action FROM lifecycle_placement_jobs WHERE request_id = $1",
+		"requestID",
+		requestID)
+
+	err := dbpool.QueryRow(
+		context.Background(),
+		"SELECT id, placement_id, status, request, lifecycle_action FROM lifecycle_placement_jobs WHERE request_id = $1",
+		requestID,
 	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.Request, &j.Action)
 	if err != nil {
 		return nil, err
@@ -188,4 +230,62 @@ func (j *LifecyclePlacementJob) SetStatus(status string) error {
 	}
 
 	return nil
+}
+
+// GlobalStatus returns the status of a LifecyclePlacementJob considering all it's children
+func (j *LifecyclePlacementJob) GlobalStatus() (string, error) {
+	if j.Status != "successfully_dispatched" {
+		return j.Status, nil
+	}
+
+	rows, err := j.DbPool.Query(
+		context.TODO(),
+		`SELECT id FROM lifecycle_resource_jobs
+         WHERE lifecycle_action = 'status'
+         AND parent_id = $1
+         ORDER BY updated_at`,
+		j.ID,
+	)
+
+	if err != nil {
+		return "unknown", err
+	}
+
+	defer rows.Close()
+
+	status := "unknown"
+	for rows.Next() {
+		var idR int
+		err := rows.Scan(&idR)
+		if err != nil {
+			return "unknown", err
+		}
+
+		job, err := GetLifecycleResourceJob(j.DbPool, idR)
+
+		if err != nil {
+			return "unknown", err
+		}
+
+		switch job.Status {
+		case "error":
+			return "error", nil
+		case "new":
+			return "new", nil
+		case "running":
+			return "running", nil
+		case "initializing":
+			return "initializing", nil
+		case "initialized":
+			return "initialized", nil
+		case "success":
+			// Save as the last status and move to the next job
+			status = "success"
+		}
+	}
+
+	if rows.Err() != nil {
+		return "unknown", err
+	}
+	return status, nil
 }


### PR DESCRIPTION
Requests are asynchronous. Anarchy needs to be able to query status of a specific request identified by an ID.

Switch to nanoid for convenience as they are URL-friendly.