### PR TITLE
Relaunch workers if they fail

### DIFF
--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -153,7 +153,7 @@ func main() {
 	// Create AWS STS client
 	worker := NewWorker(*baseHandler)
 
-	go worker.WatchLifecycleDBChannels()
+	go worker.WatchLifecycleDBChannels(context.Background())
 
 	// ---------------------------------------------------------------------
 	// Middlewares


### PR DESCRIPTION
goroutine can fail. This change adds a restart mechanism.

* use context to cancel sub go routines
* log when this happens

Simulating postgresql connection fail with `iptables -j DROP`, workers are correctly created again:

```
{"time":"2023-08-30T20:45:52.478661873+02:00","level":"INFO","msg":"Starting sandbox-api"}
{"time":"2023-08-30T20:45:53.913977014+02:00","level":"INFO","msg":"Listening on port 8080"}
{"time":"2023-08-30T20:45:55.096949169+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_placement_jobs_status_channel"}
{"time":"2023-08-30T20:45:55.367386375+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_resource_jobs_status_channel"}

{"time":"2023-08-30T20:57:09.639526226+02:00","level":"ERROR","msg":"Error while listening to the channel","error":"read tcp 10.132.31.1:43878->34.223.242.215:54327: read: connection reset by peer"}
{"time":"2023-08-30T20:59:15.67049891+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (timeout: dial tcp 34.223.242.215:54327: i/o timeout)"}
{"time":"2023-08-30T21:01:17.529920318+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (timeout: dial tcp 34.223.242.215:54327: i/o timeout)"}
{"time":"2023-08-30T21:03:18.549570876+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (timeout: dial tcp 34.223.242.215:54327: i/o timeout)"}
{"time":"2023-08-31T09:46:52.504983568+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_placement_jobs_status_channel"}
{"time":"2023-08-31T09:46:52.670307669+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_resource_jobs_status_channel"}
```
