### PR TITLE
Relaunch workers if they fail

### DIFF
--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -153,7 +153,7 @@ func main() {
 	// Create AWS STS client
 	worker := NewWorker(*baseHandler)
 
-	go worker.WatchLifecycleDBChannels()
+	go worker.WatchLifecycleDBChannels(context.Background())
 
 	// ---------------------------------------------------------------------
 	// Middlewares

--- a/cmd/sandbox-api/workers.go
+++ b/cmd/sandbox-api/workers.go
@@ -228,11 +228,6 @@ func (w Worker) WatchLifecycleDBChannels(ctx context.Context) error {
 		go w.WatchLifecycleDBChannels(context.Background())
 	}()
 
-	// Create go routines to listen to the Golang channels
-	for i := 0; i < workers; i++ {
-		go w.consumeChannels(ctx, LifecycleResourceJobsStatusChannel, LifecyclePlacementJobsStatusChannel)
-	}
-
 	conn, err := w.Dbpool.Acquire(context.Background())
 	if err != nil {
 		log.Logger.Error("Error acquiring connection", "error", err)
@@ -251,6 +246,11 @@ func (w Worker) WatchLifecycleDBChannels(ctx context.Context) error {
 			return err
 		}
 		log.Logger.Info("Listening to channel", "channel", pgChan)
+	}
+
+	// Create go routines to listen to the Golang channels
+	for i := 0; i < workers; i++ {
+		go w.consumeChannels(ctx, LifecycleResourceJobsStatusChannel, LifecyclePlacementJobsStatusChannel)
 	}
 
 	for {

--- a/todo.org
+++ b/todo.org
@@ -14,9 +14,9 @@
 *** DONE GET one
 *** DONE PUT (mark for cleanup)
 ** Lifecycle
-*** TODO STOP
-*** TODO START
-*** TODO STATUS
+*** DONE STOP
+*** DONE START
+*** DONE STATUS
 * DONE validate requests using the openAPI schema
 * DONE embed the schema in binary
 * DONE add credential type
@@ -55,10 +55,11 @@
 *** DONE proper lifecyclePlacementResponse with examples
 * DONE OpenShift limit and req for pods
 * TODO patch clients (sandbox-list, mark_for_cleanup script, etc) to use the sandbox-API instead of dynamodb
-* TODO unit tests and fixture/functional tests
 * TODO documentation coverage
 * TODO move handlers per version?
 * Post MVP
+** TODO unit tests and fixture/functional tests
+** TODO prometheus endpoint and metrics
 ** TODO Encrypt IAM secret key using AWS KMS instead of ansible-vault.  Use and support both while transitioning
 ** TODO aws lambda function to replicate changes from dynamoDB to postgresql
 ** TODO add POST /refresh   to get new access token


### PR DESCRIPTION
goroutine can fail. This change adds a restart mechanism.

* use context to cancel sub go routines
* log when this happens

Simulating postgresql connection fail with `iptables -j DROP`, workers are correctly created again:

```



{"time":"2023-08-30T20:45:52.478661873+02:00","level":"INFO","msg":"Starting sandbox-api"}
{"time":"2023-08-30T20:45:53.913977014+02:00","level":"INFO","msg":"Listening on port 8080"}
{"time":"2023-08-30T20:45:55.096949169+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_placement_jobs_status_channel"}
{"time":"2023-08-30T20:45:55.367386375+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_resource_jobs_status_channel"}
{"time":"2023-08-31T10:58:57.545294913+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (dial tcp 34.223.242.215:54327: connect: connection refused)"}
{"time":"2023-08-31T10:58:57.545356551+02:00","level":"WARN","msg":"Restarting worker WatchLifecycleDBChannels and its workers"}
{"time":"2023-08-31T10:58:57.54537803+02:00","level":"WARN","msg":"Context cancelled, exiting consumeChannels worker"}
{"time":"2023-08-31T10:58:57.545403852+02:00","level":"WARN","msg":"Context cancelled, exiting consumeChannels worker"}
{"time":"2023-08-31T10:58:57.545394056+02:00","level":"WARN","msg":"Context cancelled, exiting consumeChannels worker"}
{"time":"2023-08-31T10:58:57.545413774+02:00","level":"WARN","msg":"Context cancelled, exiting consumeChannels worker"}
{"time":"2023-08-31T10:58:57.545397433+02:00","level":"WARN","msg":"Context cancelled, exiting consumeChannels worker"}
{"time":"2023-08-31T10:59:58.011871662+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (dial tcp 34.223.242.215:54327: connect: connection refused)"}
[LOOPING every 5 seconds]
{"time":"2023-08-31T10:59:58.011871662+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (dial tcp 34.223.242.215:54327: connect: connection refused)"}
{"time":"2023-08-31T10:59:58.011871662+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (dial tcp 34.223.242.215:54327: connect: connection refused)"}
{"time":"2023-08-31T10:59:58.011871662+02:00","level":"ERROR","msg":"Error acquiring connection","error":"failed to connect to `host=dev-cluster.cq9x3fy91t7b.us-west-2.rds.amazonaws.com user=postgres database=sandbox_api_dev`: dial error (dial tcp 34.223.242.215:54327: connect: connection refused)"}


[...]
{"time":"2023-08-31T11:00:39.721541562+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_placement_jobs_status_channel"}
{"time":"2023-08-31T11:00:39.9672589+02:00","level":"INFO","msg":"Listening to channel","channel":"lifecycle_resource_jobs_status_channel"}
```