### PR TITLE
Fix workers: Ignore accounts marked for cleanup

### DIFF
--- a/cmd/sandbox-api/handlers.go
+++ b/cmd/sandbox-api/handlers.go
@@ -255,7 +255,7 @@ func (h *BaseHandler) GetPlacementHandler(w http.ResponseWriter, r *http.Request
 		log.Logger.Error("GetPlacementHandler", "error", err)
 		return
 	}
-	placement.LoadResourcesWithCreds(h.accountProvider)
+	placement.LoadActiveResourcesWithCreds(h.accountProvider)
 
 	w.WriteHeader(http.StatusOK)
 	render.Render(w, r, placement)
@@ -333,7 +333,7 @@ func (h *BaseHandler) LifeCyclePlacementHandler(action string) http.HandlerFunc 
 		if err == pgx.ErrNoRows {
 			// Legacy services don't have a placement, but stop them anyway
 
-			accounts, err := h.accountProvider.FetchAllByServiceUuid(serviceUuid)
+			accounts, err := h.accountProvider.FetchAllActiveByServiceUuid(serviceUuid)
 			if err != nil {
 				log.Logger.Error("GET accounts", "error", err)
 
@@ -436,7 +436,7 @@ func (h *BaseHandler) GetStatusPlacementHandler(w http.ResponseWriter, r *http.R
 	if err == pgx.ErrNoRows {
 		// Legacy services don't have a placement, but get status using the serviceUUID
 
-		accounts, err := h.accountProvider.FetchAllByServiceUuid(serviceUuid)
+		accounts, err := h.accountProvider.FetchAllActiveByServiceUuid(serviceUuid)
 		if err != nil {
 			log.Logger.Error("GET accounts", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/sandbox-api/workers.go
+++ b/cmd/sandbox-api/workers.go
@@ -165,7 +165,7 @@ WorkerLoop:
 				}
 
 				// Get all accounts in the placement
-				if err := placement.LoadResources(w.AccountProvider); err != nil {
+				if err := placement.LoadActiveResources(w.AccountProvider); err != nil {
 					log.Logger.Error("Error loading resources", "error", err, "placement", placement)
 					job.SetStatus("error")
 					continue WorkerLoop

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -355,9 +355,31 @@ func (a *AwsAccountDynamoDBProvider) FetchAllByServiceUuid(serviceUuid string) (
 	return makeAccounts(accounts), nil
 }
 
-// FetchAllByServiceUuid returns the list of accounts from dynamodb for a specific service uuid
+// FetchAllActiveByServiceUuid returns the list of accounts from dynamodb for a specific service uuid that are not to cleanup
+func (a *AwsAccountDynamoDBProvider) FetchAllActiveByServiceUuid(serviceUuid string) ([]models.AwsAccount, error) {
+	filter := expression.Name("service_uuid").Equal(expression.Value(serviceUuid)).
+		And(expression.Name("to_cleanup").Equal(expression.Value(false)))
+	accounts, err := GetAccounts(a.Svc, filter, -1)
+	if err != nil {
+		return []models.AwsAccount{}, err
+	}
+	return makeAccounts(accounts), nil
+}
+
+// FetchAllByServiceUuidWithCreds returns the list of accounts from dynamodb for a specific service uuid
 func (a *AwsAccountDynamoDBProvider) FetchAllByServiceUuidWithCreds(serviceUuid string) ([]models.AwsAccountWithCreds, error) {
 	filter := expression.Name("service_uuid").Equal(expression.Value(serviceUuid))
+	accounts, err := GetAccounts(a.Svc, filter, -1)
+	if err != nil {
+		return []models.AwsAccountWithCreds{}, err
+	}
+	return a.makeAccountsWithCreds(accounts), nil
+}
+
+// FetchAllActiveByServiceUuidWithCreds returns the list of accounts from dynamodb for a specific service uuid
+func (a *AwsAccountDynamoDBProvider) FetchAllActiveByServiceUuidWithCreds(serviceUuid string) ([]models.AwsAccountWithCreds, error) {
+	filter := expression.Name("service_uuid").Equal(expression.Value(serviceUuid)).
+		And(expression.Name("to_cleanup").Equal(expression.Value(false)))
 	accounts, err := GetAccounts(a.Svc, filter, -1)
 	if err != nil {
 		return []models.AwsAccountWithCreds{}, err

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -60,7 +60,9 @@ type AwsAccountProvider interface {
 	FetchAllToCleanup() ([]AwsAccount, error)
 	FetchAllSorted(by string) ([]AwsAccount, error)
 	FetchAllByServiceUuid(serviceUuid string) ([]AwsAccount, error)
+	FetchAllActiveByServiceUuid(serviceUuid string) ([]AwsAccount, error)
 	FetchAllByServiceUuidWithCreds(serviceUuid string) ([]AwsAccountWithCreds, error)
+	FetchAllActiveByServiceUuidWithCreds(serviceUuid string) ([]AwsAccountWithCreds, error)
 	Request(service_uuid string, count int, annotations map[string]string) ([]AwsAccountWithCreds, error)
 	MarkForCleanup(name string) error
 	MarkForCleanupByServiceUuid(serviceUuid string) error

--- a/internal/models/placements.go
+++ b/internal/models/placements.go
@@ -70,6 +70,40 @@ func (p *Placement) LoadResourcesWithCreds(accountProvider AwsAccountProvider) e
 	return nil
 }
 
+func (p *Placement) LoadActiveResources(accountProvider AwsAccountProvider) error {
+	accounts, err := accountProvider.FetchAllActiveByServiceUuid(p.ServiceUuid)
+
+	if err != nil {
+		return err
+	}
+
+	p.Resources = []any{}
+
+	for _, account := range accounts {
+		p.Resources = append(p.Resources, account)
+	}
+
+	return nil
+}
+
+func (p *Placement) LoadActiveResourcesWithCreds(accountProvider AwsAccountProvider) error {
+
+	accounts, err := accountProvider.FetchAllActiveByServiceUuidWithCreds(p.ServiceUuid)
+
+	if err != nil {
+		return err
+	}
+
+	p.Resources = []any{}
+
+	for _, account := range accounts {
+		p.Resources = append(p.Resources, account)
+	}
+
+	return nil
+}
+
+
 func (p *Placement) Save(dbpool *pgxpool.Pool) error {
 	var id int
 	// Check if placement already exists in the DB

--- a/tests/000.hurl
+++ b/tests/000.hurl
@@ -104,7 +104,7 @@ GET http://{{host}}/api/v1/placements/{{uuid}}/status
 Authorization: Bearer {{access_token}}
 HTTP 200
 [Asserts]
-jsonpath "$.status" count == 1
+jsonpath "$.status" count >= 1
 jsonpath "$.status[0].account_name" == "{{account}}"
 jsonpath "$.status[0].account_kind" == "aws_account"
 jsonpath "$.status[0].status" == "success"

--- a/todo.org
+++ b/todo.org
@@ -54,6 +54,7 @@
 *** DONE test legacy placement/stop/start/status
 *** DONE proper lifecyclePlacementResponse with examples
 * DONE OpenShift limit and req for pods
+* DONE unit tests and fixture/functional tests
 * TODO patch clients (sandbox-list, mark_for_cleanup script, etc) to use the sandbox-API instead of dynamodb
 * TODO documentation coverage
 * TODO move handlers per version?


### PR DESCRIPTION
Re-using the same uuid in functional tests releaved a minor bug where
listings of resources or jobs of a placement (when same UUID is used) are polluted by old
accounts marked for cleanup. Even if the preivious placemement is deleted.

This is considered minor because it won't happen in production as we never re-use uuids.
But it should be fixed nevertheless.

This commit introduces new functions `FetchAllActiveByUuid` to ignore accounts already marked for cleanup and use that
instead of the previous functions.