### PR TITLE
Fix building image, use bulleye

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -3,4 +3,3 @@ deploy/lambda/*.zip
 Containerfile*
 .containerignore
 .dev.*
-.git

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,14 +1,8 @@
 ARG GO_VERSION=1.21
 # Switch back to Red Hat go-toolset when it supports go 1.20
 #FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
-FROM docker.io/golang:${GO_VERSION} as builder
+FROM docker.io/golang:${GO_VERSION}-bullseye as builder
 WORKDIR /sandbox/
-
-
-USER root
-RUN chown -R ${USER_UID}:0 /sandbox
-USER ${USER_UID}
-
 COPY ./ ./
 RUN make sandbox-api
 


### PR DESCRIPTION
fixes:

make: /bin/sh: Operation not permitted
make: date: Operation not permitted
make: /bin/sh: Operation not permitted

Also remove .git from .containerignore as it's needed when building to inject version information.