### PR TITLE
Add more info when stopping/starting instances

### DIFF
--- a/cmd/sandbox-api/workers.go
+++ b/cmd/sandbox-api/workers.go
@@ -73,7 +73,7 @@ func (w Worker) Execute(j *models.LifecycleResourceJob) error {
 		ctx := context.TODO()
 
 		// Add RequestID to context
-		ctx = context.WithValue(ctx, "RequestID", string(j.RequestID))
+		ctx = context.WithValue(ctx, "RequestID", j.RequestID)
 		// If job has a parent, add serviceUUID to context
 		if j.ParentID != 0 {
 			// Load parent job from DB

--- a/cmd/sandbox-api/workers.go
+++ b/cmd/sandbox-api/workers.go
@@ -69,16 +69,42 @@ func (w Worker) Execute(j *models.LifecycleResourceJob) error {
 		}
 
 		log.Logger.Debug("assume successful")
+
+		ctx := context.TODO()
+
+		// Add RequestID to context
+		ctx = context.WithValue(ctx, "RequestID", string(j.RequestID))
+		// If job has a parent, add serviceUUID to context
+		if j.ParentID != 0 {
+			// Load parent job from DB
+			parentJob, err := models.GetLifecyclePlacementJob(w.Dbpool, j.ParentID)
+
+			if err != nil {
+				log.Logger.Error("Error getting parent job", "error", err)
+				return err
+			}
+
+			// Load placement from DB
+			placement, err := models.GetPlacement(w.Dbpool, parentJob.PlacementID)
+			if err != nil {
+				log.Logger.Error("Error getting placement", "error", err)
+				return err
+			}
+
+			// Add service UUID to context
+			ctx = context.WithValue(ctx, "ServiceUUID", placement.ServiceUuid)
+		}
+
 		switch j.Action {
 		case "start":
 			j.SetStatus("running")
-			return sandbox.Start(assume.Credentials)
+			return sandbox.Start(ctx, assume.Credentials)
 		case "stop":
 			j.SetStatus("running")
-			return sandbox.Stop(assume.Credentials)
+			return sandbox.Stop(ctx, assume.Credentials)
 		case "status":
 			j.SetStatus("running")
-			status, err := sandbox.Status(assume.Credentials, j)
+			status, err := sandbox.Status(ctx, assume.Credentials, j)
 			if err != nil {
 				j.SetStatus("error")
 				log.Logger.Error("Error getting status", "error", err)

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -246,7 +246,6 @@ func GetAccount(svc *dynamodb.DynamoDB, name string) (AwsAccountDynamoDB, error)
 		log.Logger.Error("Unmarshalling dynamodb item", "error", err)
 		return AwsAccountDynamoDB{}, err
 	}
-	log.Logger.Info("GetItem succeeded", slog.String("sandbox", sandbox.Name))
 
 	return sandbox, nil
 }

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"errors"
-	"log/slog"
 	"os"
 	"sort"
 	"strconv"

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -36,7 +36,7 @@ func InitLoggers(debugFlag bool, attrs []slog.Attr) {
 	}
 
 	opts := slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level:       slog.LevelInfo,
 		ReplaceAttr: replaceAttrs,
 	}
 	if debugFlag {

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -130,7 +130,7 @@ func Sort[T Sortable](accounts []T, by string) []T {
 }
 
 // Start method starts all the stopped instances in the account
-func (a AwsAccount) Start(creds *ststypes.Credentials) error {
+func (a AwsAccount) Start(ctx context.Context, creds *ststypes.Credentials) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		log.Logger.Error("Error loading config", "error", err)
@@ -207,8 +207,8 @@ func (a AwsAccount) Start(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
-					// Get only the first 10 tags
-					"instance_tags", instance.Tags[:min(10,len(instance.Tags))],
+					"request_id", ctx.Value("RequestID"),
+					"service_uuid", ctx.Value("ServiceUUID"),
 				)
 			}
 		}
@@ -218,7 +218,7 @@ func (a AwsAccount) Start(creds *ststypes.Credentials) error {
 }
 
 // Stop method stops all the running instances in the account
-func (a AwsAccount) Stop(creds *ststypes.Credentials) error {
+func (a AwsAccount) Stop(ctx context.Context, creds *ststypes.Credentials) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		log.Logger.Error("Error loading config", "error", err)
@@ -290,8 +290,8 @@ func (a AwsAccount) Stop(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
-					// Get only the first 10 tags
-					"instance_tags", instance.Tags[:min(10,len(instance.Tags))],
+					"request_id", ctx.Value("RequestID"),
+					"service_uuid", ctx.Value("ServiceUUID"),
 				)
 			}
 		}
@@ -335,7 +335,7 @@ func MakeStatus(job *LifecycleResourceJob) Status {
 }
 
 // Status method returns the status of all the instances in the account
-func (a AwsAccount) Status(creds *ststypes.Credentials, job *LifecycleResourceJob) (Status, error) {
+func (a AwsAccount) Status(ctx context.Context, creds *ststypes.Credentials, job *LifecycleResourceJob) (Status, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		log.Logger.Error("Error loading config", "error", err)

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -201,7 +201,13 @@ func (a AwsAccount) Start(creds *ststypes.Credentials) error {
 					errR = err
 					continue
 				}
-				log.Logger.Info("Start instance", "account", a.Name, "instance_id", *instance.InstanceId)
+				log.Logger.Info("Start instance",
+					"account", a.Name,
+					"account_id", a.AccountID,
+					"instance_id", *instance.InstanceId,
+					"instance_type", instance.InstanceType,
+					"region", *region.RegionName,
+				)
 			}
 		}
 	}
@@ -276,7 +282,13 @@ func (a AwsAccount) Stop(creds *ststypes.Credentials) error {
 					errR = err
 					continue
 				}
-				log.Logger.Info("Stop instance", "account", a.Name, "instance_id", *instance.InstanceId)
+				log.Logger.Info("Stop instance",
+					"account", a.Name,
+					"account_id", a.AccountID,
+					"instance_id", *instance.InstanceId,
+					"instance_type", instance.InstanceType,
+					"region", *region.RegionName,
+				)
 			}
 		}
 	}

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -207,7 +207,8 @@ func (a AwsAccount) Start(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
-					"instance_tags", instance.Tags,
+					// Get only the first 10 tags
+					"instance_tags", instance.Tags[:min(10,len(instance.Tags))],
 				)
 			}
 		}
@@ -289,7 +290,8 @@ func (a AwsAccount) Stop(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
-					"instance_tags", instance.Tags,
+					// Get only the first 10 tags
+					"instance_tags", instance.Tags[:min(10,len(instance.Tags))],
 				)
 			}
 		}

--- a/internal/models/aws_account.go
+++ b/internal/models/aws_account.go
@@ -207,6 +207,7 @@ func (a AwsAccount) Start(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
+					"instance_tags", instance.Tags,
 				)
 			}
 		}
@@ -288,6 +289,7 @@ func (a AwsAccount) Stop(creds *ststypes.Credentials) error {
 					"instance_id", *instance.InstanceId,
 					"instance_type", instance.InstanceType,
 					"region", *region.RegionName,
+					"instance_tags", instance.Tags,
 				)
 			}
 		}

--- a/internal/models/lifecycle_jobs.go
+++ b/internal/models/lifecycle_jobs.go
@@ -43,9 +43,9 @@ func GetLifecycleResourceJob(dbpool *pgxpool.Pool, id int) (*LifecycleResourceJo
 
 	err := dbpool.QueryRow(
 		context.Background(),
-		"SELECT id, COALESCE(parent_id, 0), resource_name, resource_type, status, request, lifecycle_result, lifecycle_action, updated_at, locality FROM lifecycle_resource_jobs WHERE id = $1",
+		"SELECT id, COALESCE(parent_id, 0), resource_name, resource_type, status, request_id, request, lifecycle_result, lifecycle_action, updated_at, locality FROM lifecycle_resource_jobs WHERE id = $1",
 		id,
-	).Scan(&j.ID, &j.ParentID, &j.ResourceName, &j.ResourceType, &j.Status, &j.Request, &j.Result, &j.Action, &j.UpdatedAt, &j.Locality)
+	).Scan(&j.ID, &j.ParentID, &j.ResourceName, &j.ResourceType, &j.Status, &j.RequestID, &j.Request, &j.Result, &j.Action, &j.UpdatedAt, &j.Locality)
 
 	if err != nil {
 		return nil, err
@@ -80,9 +80,9 @@ func GetLifecyclePlacementJob(dbpool *pgxpool.Pool, id int) (*LifecyclePlacement
 
 	err := dbpool.QueryRow(
 		context.Background(),
-		"SELECT id, placement_id, status, request, lifecycle_action, locality FROM lifecycle_placement_jobs WHERE id = $1",
+		"SELECT id, placement_id, status, request_id, request, lifecycle_action, locality FROM lifecycle_placement_jobs WHERE id = $1",
 		id,
-	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.Request, &j.Action, &j.Locality)
+	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.RequestID, &j.Request, &j.Action, &j.Locality)
 	if err != nil {
 		return nil, err
 	}
@@ -98,9 +98,9 @@ func GetLifecyclePlacementJobByRequestID(dbpool *pgxpool.Pool, requestID string)
 
 	err := dbpool.QueryRow(
 		context.Background(),
-		"SELECT id, placement_id, status, request, lifecycle_action, locality FROM lifecycle_placement_jobs WHERE request_id = $1",
+		"SELECT id, placement_id, status, request_id, request, lifecycle_action, locality FROM lifecycle_placement_jobs WHERE request_id = $1",
 		requestID,
-	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.Request, &j.Action, &j.Locality)
+	).Scan(&j.ID, &j.PlacementID, &j.Status, &j.RequestID, &j.Request, &j.Action, &j.Locality)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/placement_action.hurl
+++ b/tools/placement_action.hurl
@@ -1,0 +1,21 @@
+#################################################################################
+# Get an access token using the login token
+#################################################################################
+
+GET http://{{host}}/api/v1/login
+Authorization: Bearer {{login_token}}
+HTTP 200
+[Captures]
+access_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+
+#################################################################################
+# Stop a placement
+#################################################################################
+
+PUT http://{{host}}/api/v1/placements/{{uuid}}/{{action}}
+Authorization: Bearer {{access_token}}
+HTTP 202

--- a/tools/sandbox_action.hurl
+++ b/tools/sandbox_action.hurl
@@ -1,0 +1,21 @@
+#################################################################################
+# Get an access token using the login token
+#################################################################################
+
+GET http://{{host}}/api/v1/login
+Authorization: Bearer {{login_token}}
+HTTP 200
+[Captures]
+access_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+
+#################################################################################
+# Stop a placement
+#################################################################################
+
+PUT http://{{host}}/api/v1/accounts/{{type}}/{{name}}/{{action}}
+Authorization: Bearer {{access_token}}
+HTTP 202


### PR DESCRIPTION
When using `PUT /api/v1/placements/<UUID>/stop`, output now looks like:

```json
{"timestamp":"2023-11-14T12:55:53.320836007+01:00","level":"INFO","msg":"Stop instance","version":"development","buildTime":"undefined","buildCommit":"HEAD","locality":"9chK0clk0cjlbask83B7-","account":"sandboxXXX","account_id":"XXXXXXXX","instance_id":"i-0137bbfd39bfe55ad","instance_type":"t2.micro","region":"us-east-1","request_id":"YJU2ichdeXb7Ig-FMSjl-","service_uuid":"a7cf3f82-f239-5faf-9830-xxxxxxxx"}
```

When using the `PUT /api/v1/accounts/AwsSandbox/<NAME>/stop`, output looks like:

```json
{"timestamp":"2023-11-14T12:59:26.601276703+01:00","level":"INFO","msg":"Start instance","version":"development","buildTime":"undefined","buildCommit":"HEAD","locality":"9chK0clk0cjlbask83B7-","account":"sandboxXXXX","account_id":"XXXXXXXX","instance_id":"i-0137bbfd39bfe55ad","instance_type":"t2.micro","region":"us-east-1","request_id":"sOuI9E-A8rumxNXe-9VG5","service_uuid":null}
```

NOTE service_uuid is `null` in that case as that endpoint is by-passing the service and interact with the account directly.