### PR TITLE
Add manual cleanup for ECR public repository

### DIFF
--- a/playbooks/roles/infra-aws-sandbox/files/manual_cleanup.py
+++ b/playbooks/roles/infra-aws-sandbox/files/manual_cleanup.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import boto3
+
+changed = False
+
+# Cleanup Public ECR
+client = boto3.client('ecr-public')
+
+response = client.describe_repositories()
+
+for repo in response['repositories']:
+    # Delete all images inside the repository
+    # Get all images
+    response2 = client.describe_images(repositoryName=repo['repositoryName'])
+
+    # Delete all images
+    for image in response2['imageDetails']:
+        client.batch_delete_image(
+            repositoryName=repo['repositoryName'],
+            imageIds=[
+                {
+                    'imageDigest': image['imageDigest']
+                }
+            ]
+        )
+        changed = True
+
+        print("Deleted image: " + image['imageDigest'])
+
+    # Delete repository
+
+    client.delete_repository(
+        repositoryName=repo['repositoryName']
+    )
+    print("Deleted repository: " + repo['repositoryName'])
+    changed = True
+
+
+# Display Change
+if changed:
+    print("Changes were made")

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -10,7 +10,14 @@
     - debug:
         var: _region
 
+    - name: Run files/manual_cleanup.py script
+      script: files/manual_cleanup.py
+      register: r_manual_cleanup
+      changed_when: >-
+        'Changes were made' in r_manual_cleanup.stdout
+
     # Reject all VPC connections
+
 
     - name: Get all VPC endpoint connections
       command: >-

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -16,8 +16,11 @@
       changed_when: >-
         'Changes were made' in r_manual_cleanup.stdout
 
-    # Reject all VPC connections
+    - name: Print output of manual_cleanup.py
+      debug:
+        var: r_manual_cleanup
 
+    # Reject all VPC connections
 
     - name: Get all VPC endpoint connections
       command: >-


### PR DESCRIPTION
Looping over resources and resource types in Ansible is *very* slow, start using a python script instead