### PR TITLE
Add the ability to specify a namespace suffix via annotations

### DIFF
--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -615,7 +615,6 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 	// Determine guid, auto increment the guid if there are multiple resources
 	// for a serviceUuid
 	guid, err := guessNextGuid(annotations["guid"], serviceUuid, a.DbPool, multiple, ctx)
-	log.Logger.Info("Guessed guid", "guid", guid)
 	if err != nil {
 		log.Logger.Error("Error guessing guid", "error", err)
 		return OcpSandboxWithCreds{}, err
@@ -748,7 +747,6 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 			suffix = serviceUuid
 		}
 
-		// Try with original guid first
 		namespaceName := "sandbox-" + guid + "-" + suffix
 		namespaceName = namespaceName[:min(63, len(namespaceName))] // truncate to 63
 

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -155,6 +155,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
+    "test": "cloud_selector too restrictive",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -192,6 +193,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
+    "test": "placement with multiple Ocp",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -265,6 +267,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
+    "test": "failed placement with multiple Ocp with one that cannot schedule",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -300,6 +303,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
+    "tests": "Simple OcpSandbox placement",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -346,6 +350,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
+    "test":"Should not be created as it's 409",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -407,6 +412,7 @@ Authorization: Bearer {{access_token}}
     {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "prod"}}
   ],
   "annotations": {
+    "test": "Placement with 3 sandboxes with namespace suffix",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
@@ -434,13 +440,22 @@ jsonpath "$.service_uuid" == "{{uuid}}"
 jsonpath "$.status" == "success"
 jsonpath "$.resources" count == 3
 jsonpath "$.resources[0].status" == "success"
-jsonpath "$.resources[0].namespace" == "sandbox-testg-dev"
-jsonpath "$.resources[1].namespace" == "sandbox-testg-2-test"
-jsonpath "$.resources[2].namespace" == "sandbox-testg-3-prod"
-jsonpath "$.resources[0].ingress_domain" split "." count > 2
-jsonpath "$.resources[0].credentials" count >= 1
-jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
-jsonpath "$.resources[0].credentials[0].token" isString
+jsonpath "$.resources[1].status" == "success"
+jsonpath "$.resources[2].status" == "success"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'dev')].namespace" includes "sandbox-testg-1-dev"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'test')].namespace" includes "sandbox-testg-2-test"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'prod')].namespace" includes "sandbox-testg-3-prod"
+
+#################################################################################
+# Get all OcpSandboxes using service_uuid query
+#################################################################################
+GET {{host}}/api/v1/accounts/OcpSandbox
+Authorization: Bearer {{access_token}}
+[QueryStringParams]
+service_uuid: {{uuid}}
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.service_uuid=='{{uuid}}')]" count == 3
 
 #################################################################################
 # Delete placement
@@ -465,6 +480,7 @@ Authorization: Bearer {{access_token}}
     {"kind": "AwsSandbox", "annotations":{"purpose":"aws"}}
   ],
   "annotations": {
+    "test": "Placement with both AWS + OCP",
     "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -155,7 +155,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -192,7 +192,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -265,7 +265,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -300,7 +300,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -346,7 +346,7 @@ Authorization: Bearer {{access_token}}
     }
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -393,6 +393,64 @@ Authorization: Bearer {{access_token}}
 retry: 40
 HTTP 404
 
+#################################################################################
+# Create a new placement With 3 sandboxes with namespace suffix
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "dev"}},
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "test"}},
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "prod"}}
+  ],
+  "annotations": {
+    "guid": "testg",
+    "env_type": "ocp4-cluster-blablablabla"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 3
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 3
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].namespace" == "sandbox-testg-dev"
+jsonpath "$.resources[1].namespace" == "sandbox-testg-2-test"
+jsonpath "$.resources[2].namespace" == "sandbox-testg-3-prod"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+
+#################################################################################
+# Delete placement
+#################################################################################
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
 
 #################################################################################
 # Create a new placement With AWS + OCP
@@ -407,7 +465,7 @@ Authorization: Bearer {{access_token}}
     {"kind": "AwsSandbox", "annotations":{"purpose":"aws"}}
   ],
   "annotations": {
-    "guid": "testg-1",
+    "guid": "testg",
     "env_type": "ocp4-cluster-blablablabla"
   }
 }
@@ -417,7 +475,7 @@ jsonpath "$.message" == "Placement Created"
 jsonpath "$.Placement.service_uuid" == "{{uuid}}"
 jsonpath "$.Placement.resources" count == 2
 jsonpath "$.Placement.resources[0].status" == "initializing"
-jsonpath "$.Placement.resources[0].annotations.guid" == "testg-1"
+jsonpath "$.Placement.resources[0].annotations.guid" == "testg"
 jsonpath "$.Placement.resources[0].annotations.purpose" == "ocp"
 
 #################################################################################


### PR DESCRIPTION
By default, OCPSandbox namespaces are named: `sandbox-GUID-UUID`

This change, if applied, allow catalog maintainers to specify a namespace suffix:

```yaml
__meta__:
  sandboxes:
  - kind: OcpSandbox
    annotation:
      namespace_suffix: devci
  - kind: OcpSandbox
    annotation:
      namespace_suffix: testci
  - kind: OcpSandbox
    annotation:
      namespace_suffix: prodci

```

Which will create those namespaces:

- `sandbox-GUID-1-devci`
- `sandbox-GUID-2-testci`
- `sandbox-GUID-3-prodci`

instead of 

- `sandbox-GUID-1-UUID`
- `sandbox-GUID-2-UUID`
- `sandbox-GUID-3-UUID`