### PR TITLE
Make Placement deletion asynchronous

### DIFF
--- a/db/migrations/008_placements_status.down.sql
+++ b/db/migrations/008_placements_status.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Drop the column 'status' if it exists, from the placements table
+ALTER TABLE placements DROP COLUMN IF EXISTS status;
+
+-- Drop type placement_status_enum if it exists
+DROP TYPE IF EXISTS placement_status_enum;
+
+-- Drop the column 'to_cleanup' from the placements table
+ALTER TABLE placements DROP COLUMN IF EXISTS to_cleanup;
+ALTER TABLE placements DROP COLUMN IF EXISTS cleanup_count;
+
+COMMIT;

--- a/db/migrations/008_placements_status.up.sql
+++ b/db/migrations/008_placements_status.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+--                                                                 Table "public.placements"
+--     Column    |           Type           | Collation | Nullable |             Default              | Storage  | Compression | Stats target | Description
+-- --------------+--------------------------+-----------+----------+----------------------------------+----------+-------------+--------------+-------------
+--  id           | bigint                   |           | not null | generated always as identity     | plain    |             |              |
+--  service_uuid | uuid                     |           | not null |                                  | plain    |             |              |
+--  created_at   | timestamp with time zone |           | not null | (now() AT TIME ZONE 'utc'::text) | plain    |             |              |
+--  updated_at   | timestamp with time zone |           | not null | (now() AT TIME ZONE 'utc'::text) | plain    |             |              |
+--  request      | jsonb                    |           |          | '{}'::jsonb                      | extended |             |              |
+--  annotations  | jsonb                    |           |          | '{}'::jsonb                      | extended |             |              |
+-- Indexes:
+--     "placements_pkey" PRIMARY KEY, btree (id)
+--     "placements_service_uuid_key" UNIQUE CONSTRAINT, btree (service_uuid)
+-- Referenced by:
+--     TABLE "lifecycle_placement_jobs" CONSTRAINT "lifecycle_placement_jobs_placement_id_fkey" FOREIGN KEY (placement_id) REFERENCES placements(id) ON DELETE CASCADE
+--     TABLE "resources" CONSTRAINT "resources_placement_id_fkey" FOREIGN KEY (placement_id) REFERENCES placements(id) ON DELETE CASCADE
+-- Triggers:
+--     placement_delete BEFORE DELETE ON placements FOR EACH ROW EXECUTE FUNCTION placement_del()
+--     placements_updated_at BEFORE UPDATE ON placements FOR EACH ROW EXECUTE FUNCTION updated_at_column()
+-- Access method: heap
+
+
+-- Create placement_status type
+CREATE TYPE placement_status_enum AS ENUM ('new', 'initializing', 'scheduling', 'success', 'error', 'deleting');
+-- add column status to placements
+ALTER TABLE placements ADD COLUMN status placement_status_enum NOT NULL DEFAULT 'new';
+-- Update all previous placements to have status 'success'
+UPDATE placements SET status = 'success';
+
+-- Add a column 'to_cleanup' to the placements table
+ALTER TABLE placements ADD COLUMN to_cleanup BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add a column 'cleanup_count' to the placements table
+ALTER TABLE placements ADD COLUMN cleanup_count INT DEFAULT 0 NOT NULL;
+
+COMMIT;

--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -352,12 +352,12 @@ func (a *OcpSandboxWithCreds) Update() error {
 		context.Background(),
 		`UPDATE resources
 		 SET resource_name = $1,
-             resource_type = $2,
-             service_uuid = $3,
-             resource_data = $4,
-             resource_credentials = pgp_sym_encrypt($5::text, $6),
-             status = $7,
-             cleanup_count = $8
+			 resource_type = $2,
+			 service_uuid = $3,
+			 resource_data = $4,
+			 resource_credentials = pgp_sym_encrypt($5::text, $6),
+			 status = $7,
+			 cleanup_count = $8
 		 WHERE id = $9`,
 		a.Name,
 		a.Kind,
@@ -400,9 +400,9 @@ func (a *OcpSandboxWithCreds) SetStatus(status string) error {
 	_, err := a.Provider.DbPool.Exec(
 		context.Background(),
 		fmt.Sprintf(`UPDATE resources
-         SET status = $1,
-             resource_data['status'] = to_jsonb('%s'::text)
-         WHERE id = $2`, status),
+		 SET status = $1,
+			 resource_data['status'] = to_jsonb('%s'::text)
+		 WHERE id = $2`, status),
 		status, a.ID,
 	)
 
@@ -1073,7 +1073,7 @@ func (a *OcpSandboxProvider) FetchAll() ([]OcpSandbox, error) {
 		context.Background(),
 		`SELECT
 		 r.resource_data,
-         r.id,
+		 r.id,
 		 r.resource_name,
 		 r.resource_type,
 		 r.created_at,
@@ -1270,6 +1270,12 @@ func (account *OcpSandboxWithCreds) Delete() error {
 		account.SetStatus("error")
 		return err
 	}
+
+	log.Logger.Info("Namespace deleted",
+		"name", account.Name,
+		"namespace", account.Namespace,
+		"cluster", account.OcpSharedClusterConfigurationName,
+	)
 
 	// Delete the Service Account
 	if err = clientset.CoreV1().

--- a/tests/000.hurl
+++ b/tests/000.hurl
@@ -35,6 +35,8 @@ HTTP *
 
 GET {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
+[Options]
+retry: 10
 HTTP 404
 
 #################################################################################
@@ -197,10 +199,38 @@ jsonpath "$.message" == "start request created"
 #################################################################################
 # Delete the placement
 #################################################################################
+# Make sure the placement fails
 
 DELETE {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
+[QueryStringParams]
+failOnDelete: true
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 10
 HTTP 200
+[Asserts]
+jsonpath "$.status" == "error"
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
 
 #################################################################################
 # Ensure start request doesn't exist

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -123,7 +123,6 @@ HTTP 404
 #################################################################################
 # Ensure the placement is deleted before starting
 #################################################################################
-
 DELETE {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
 [Options]
@@ -239,6 +238,17 @@ jsonpath "$.resources[2].credentials[0].token" isString
 #################################################################################
 
 DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
 [Options]
 retry: 40
@@ -394,6 +404,10 @@ jsonpath "$.service_uuid" == "{{uuid}}"
 
 DELETE {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
 [Options]
 retry: 40
 HTTP 404
@@ -463,6 +477,10 @@ jsonpath "$[?(@.service_uuid=='{{uuid}}')]" count == 3
 
 DELETE {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
 [Options]
 retry: 40
 HTTP 404
@@ -517,8 +535,18 @@ jsonpath "$.resources[?(@.annotations.purpose == 'aws')].kind" includes "AwsSand
 #################################################################################
 # Delete placement
 #################################################################################
-
 DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
 [Options]
 retry: 40


### PR DESCRIPTION
This changes makes the `DELETE /placements` endpoint async.

- The API now returns a 202 (Accepted) instead of 200 (OK)
- Add a DbPool field to the Placement Struct for convenience (plumbing)
- DB migration: Add a 'to_cleanup' and 'status' column to the 'placements' table
- Update the placement.status mecanism to not override 'error' or 'deleting' with with the status of the resources
- Update functional tests

GPTEINFRA-9875