### PR TITLE
OcpSandbox: cleanup Role Binding of cnv-images namespace

### DIFF
--- a/tools/placement_create.hurl
+++ b/tools/placement_create.hurl
@@ -21,15 +21,27 @@ Authorization: Bearer {{access_token}}
   "service_uuid": "{{uuid}}",
   "resources": [
     {
-      "kind": "AwsSandbox",
-      "count": 1,
-      "annotations": {
-        "purpose": "backend"
-      }
+      "kind": "OcpSandbox"
     }
   ],
   "annotations": {
-    "guid": "testg"
+    "guid": "testgc"
   }
 }
 HTTP 200
+
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "success"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}

--- a/tools/placement_delete.hurl
+++ b/tools/placement_delete.hurl
@@ -18,4 +18,4 @@ jsonpath "$.access_token_exp" isString
 
 DELETE {{host}}/api/v1/placements/{{uuid}}
 Authorization: Bearer {{access_token}}
-HTTP 200
+HTTP 202


### PR DESCRIPTION
Make sure the RoleBindings for the cnv-images namespace are cleaned up.

Also don't fail if the role-binding already exists (That happens only while testing, not in production)