### PR TITLE
Implement Quota for OcpSandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL = /bin/sh
 VERSION ?= $(shell git describe --tags 2>/dev/null | cut -c 2-)
 COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
 DATE ?= $(shell date -u)
+export CGO_ENABLED=0
 
 build: sandbox-list sandbox-metrics sandbox-api sandbox-issue-jwt sandbox-rotate-vault
 
@@ -19,13 +20,17 @@ test:
 	@go run github.com/daveshanley/vacuum@latest lint -d docs/api-reference/swagger.yaml
 
 run-api: cmd/sandbox-api/assets/swagger.yaml .dev.pgenv .dev.jwtauth_env #migrate
-	. ./.dev.pgenv && . ./.dev.jwtauth_env && cd cmd/sandbox-api && CGO_ENABLED=0 go run .
+	. ./.dev.pgenv && . ./.dev.jwtauth_env && cd cmd/sandbox-api && go run .
+
+run-air: cmd/sandbox-api/assets/swagger.yaml .dev.pgenv .dev.jwtauth_env
+	. ./.dev.pgenv && . ./.dev.jwtauth_env && cd cmd/sandbox-api && air
 
 rm-local-pg:
 	@podman kill localpg || true
 	@podman rm localpg || true
+	@rm -f .dev.pg_password .dev.pgenv .dev.tokens_env .dev.admin_token .dev.app_token || true
 
-run-local-pg: .dev.pg_password rm-local-pg
+run-local-pg: rm-local-pg .dev.pg_password
 	@echo "Running local postgres..."
 	@podman run  -p 5432:5432 --name localpg -e POSTGRES_PASSWORD=$(shell cat .dev.pg_password) -d postgres:16-bullseye
 # See full list of parameters here:
@@ -33,6 +38,9 @@ run-local-pg: .dev.pg_password rm-local-pg
 
 issue-jwt: .dev.jwtauth_env
 	@. ./.dev.pgenv && . ./.dev.jwtauth_env && go run ./cmd/sandbox-issue-jwt
+
+tokens: .dev.tokens_env
+	@cat .dev.tokens_env
 
 migrate: .dev.pgenv
 # Print a message with the database URL and ask for confirmation
@@ -51,22 +59,22 @@ fixtures: migrate .dev.pgenv
 	@. ./.dev.pgenv && psql "$${DATABASE_URL}" < ./db/fixtures/0001.sql
 
 sandbox-list:
-	CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-list ./cmd/sandbox-list
+	go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-list ./cmd/sandbox-list
 
 sandbox-api: cmd/sandbox-api/assets/swagger.yaml
-	CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-api ./cmd/sandbox-api
+	go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-api ./cmd/sandbox-api
 
 sandbox-metrics:
-	CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-metrics ./cmd/sandbox-metrics
+	go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-metrics ./cmd/sandbox-metrics
 
 sandbox-issue-jwt:
-	CGO_ENABLED=0 go build -o build/sandbox-issue-jwt ./cmd/sandbox-issue-jwt
+	go build -o build/sandbox-issue-jwt ./cmd/sandbox-issue-jwt
 
 sandbox-replicate:
-	CGO_ENABLED=0 go build -o build/sandbox-replicate ./cmd/sandbox-replicate
+	go build -o build/sandbox-replicate ./cmd/sandbox-replicate
 
 sandbox-rotate-vault:
-	CGO_ENABLED=0 go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-rotate-vault ./cmd/sandbox-rotate-vault
+	go build -ldflags="-X 'main.Version=$(VERSION)' -X 'main.buildTime=$(DATE)' -X 'main.buildCommit=$(COMMIT)'" -o build/sandbox-rotate-vault ./cmd/sandbox-rotate-vault
 
 
 push-lambda: deploy/lambda/sandbox-replicate.zip
@@ -75,7 +83,7 @@ push-lambda: deploy/lambda/sandbox-replicate.zip
 fmt:
 	@go fmt ./...
 
-.PHONY: sandbox-api sandbox-issue-jwt sandbox-list sandbox-metrics sandbox-rotate-vault run-api sandbox-replicate migrate fixtures test run-local-pg push-lambda clean fmt
+.PHONY: sandbox-api sandbox-issue-jwt issue-jwt tokens sandbox-list sandbox-metrics sandbox-rotate-vault run-api run-air sandbox-replicate migrate fixtures test run-local-pg push-lambda clean fmt
 
 clean: rm-local-pg
 	rm -f build/sandbox-*
@@ -106,4 +114,14 @@ cmd/sandbox-api/assets/swagger.yaml: docs/api-reference/swagger.yaml
 	@echo "export JWT_AUTH_SECRET=$(shell cat .dev.jwtauth_secret)" > .dev.jwtauth_env
 	@chmod 600 .dev.jwtauth_env
 
+.dev.admin_token: .dev.pgenv .dev.jwtauth_env
+	@echo '{"kind": "login", "name": "dev-$(shell hostname)-$(shell date +%Y%m%d)", "role": "admin"}' | (. ./.dev.pgenv && . ./.dev.jwtauth_env && go run ./cmd/sandbox-issue-jwt) > .dev.admin_token
+
+.dev.app_token: .dev.pgenv .dev.jwtauth_env
+	@echo '{"kind": "login", "name": "dev-$(shell hostname)-$(shell date +%Y%m%d)", "role": "app"}' | (. ./.dev.pgenv && . ./.dev.jwtauth_env && go run ./cmd/sandbox-issue-jwt) > .dev.app_token
+
+.dev.tokens_env: .dev.admin_token .dev.app_token
+	@echo "export admintoken=$(shell cat .dev.admin_token)" > .dev.tokens_env
+	@echo "export apptoken=$(shell cat .dev.app_token)" >> .dev.tokens_env
+	@chmod 600 .dev.tokens_env
 # end

--- a/cmd/sandbox-api/handlers.go
+++ b/cmd/sandbox-api/handlers.go
@@ -84,6 +84,7 @@ func (h *BaseHandler) CreatePlacementHandler(w http.ResponseWriter, r *http.Requ
 			Err:            err,
 			HTTPStatusCode: http.StatusBadRequest,
 			Message:        "Error decoding request body",
+			ErrorMultiline: []string{err.Error()},
 		})
 		log.Logger.Error("CreatePlacementHandler", "error", err)
 
@@ -178,6 +179,7 @@ func (h *BaseHandler) CreatePlacementHandler(w http.ResponseWriter, r *http.Requ
 				placementRequest.ServiceUuid,
 				request.CloudSelector,
 				placementRequest.Annotations.Merge(request.Annotations),
+				request.Quota,
 				multipleOcp,
 				r.Context(),
 			)
@@ -943,6 +945,7 @@ func (h *BaseHandler) CreateReservationHandler(w http.ResponseWriter, r *http.Re
 			Err:            err,
 			HTTPStatusCode: http.StatusBadRequest,
 			Message:        "Error decoding request body",
+			ErrorMultiline: []string{err.Error()},
 		})
 		log.Logger.Error("CreateReservationHandler", "error", err)
 
@@ -1122,6 +1125,7 @@ func (h *BaseHandler) UpdateReservationHandler(w http.ResponseWriter, r *http.Re
 			Err:            err,
 			HTTPStatusCode: http.StatusBadRequest,
 			Message:        "Error decoding request body",
+			ErrorMultiline: []string{err.Error()},
 		})
 		log.Logger.Error("UpdateReservationHandler", "error", err)
 		return

--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -269,6 +269,7 @@ func main() {
 		r.Get("/api/v1/ocp-shared-cluster-configurations/{name}", baseHandler.GetOcpSharedClusterConfigurationHandler)
 		r.Put("/api/v1/ocp-shared-cluster-configurations/{name}/disable", baseHandler.DisableOcpSharedClusterConfigurationHandler)
 		r.Put("/api/v1/ocp-shared-cluster-configurations/{name}/enable", baseHandler.EnableOcpSharedClusterConfigurationHandler)
+		r.Put("/api/v1/ocp-shared-cluster-configurations/{name}/update", baseHandler.UpdateOcpSharedClusterConfigurationHandler)
 		r.Delete("/api/v1/ocp-shared-cluster-configurations/{name}", baseHandler.DeleteOcpSharedClusterConfigurationHandler)
 
 		// Reservations

--- a/cmd/sandbox-api/ocp_shared_cluster_configuration_handlers.go
+++ b/cmd/sandbox-api/ocp_shared_cluster_configuration_handlers.go
@@ -307,6 +307,10 @@ func (h *BaseHandler) UpdateOcpSharedClusterConfigurationHandler(w http.Response
 		ocpSharedClusterConfiguration.MaxCpuUsagePercentage = *input.MaxCpuUsagePercentage
 	}
 
+	if input.SkipQuota != nil {
+		ocpSharedClusterConfiguration.SkipQuota = *input.SkipQuota
+	}
+
 	if err := ocpSharedClusterConfiguration.Save(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		render.Render(w, r, &v1.Error{

--- a/cmd/sandbox-issue-jwt/main.go
+++ b/cmd/sandbox-issue-jwt/main.go
@@ -52,9 +52,12 @@ func main() {
 	}
 
 	pw := strings.Trim(string(bytepw), "\r\n\t ")
-	fmt.Println("Enter Claims in the JSON format:")
-	fmt.Println(`for example: {"kind": "login", "name": "gucore", "role": "admin"}`)
-	fmt.Println(`Finish with [Ctrl+D]`)
+	// Print help only if stdin is a terminal
+	if term.IsTerminal(int(syscall.Stdin)) {
+		fmt.Println("Enter Claims in the JSON format:")
+		fmt.Println(`for example: {"kind": "login", "name": "gucore", "role": "admin"}`)
+		fmt.Println(`Finish with [Ctrl+D]`)
+	}
 	claims, err := io.ReadAll(os.Stdin)
 
 	// json unmarshal claims
@@ -84,5 +87,9 @@ func main() {
 
 	tokenAuth := jwtauth.New("HS256", []byte(pw), nil)
 	_, tokenString, _ := tokenAuth.Encode(claimsMap)
-	fmt.Printf("token:\n%s\n", tokenString)
+	if term.IsTerminal(int(syscall.Stdin)) {
+		fmt.Printf("token:\n%s\n", tokenString)
+	} else {
+		fmt.Printf("%s\n", tokenString)
+	}
 }

--- a/db/migrations/011_quota.down.sql
+++ b/db/migrations/011_quota.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- Drop the default_sandbox_quota column from the ocp_shared_cluster_configurations table
+ALTER TABLE ocp_shared_cluster_configurations
+  DROP COLUMN default_sandbox_quota;
+
+-- Drop the strict_default_sandbox_quota column from the ocp_shared_cluster_configurations table
+ALTER TABLE ocp_shared_cluster_configurations
+  DROP COLUMN strict_default_sandbox_quota;
+
+-- Drop the quota_required column from the ocp_shared_cluster_configurations table
+ALTER TABLE ocp_shared_cluster_configurations
+  DROP COLUMN quota_required;
+
+COMMIT;

--- a/db/migrations/011_quota.up.sql
+++ b/db/migrations/011_quota.up.sql
@@ -1,0 +1,41 @@
+--                                                Table "public.ocp_shared_cluster_configurations"
+--            Column            |           Type           | Collation | Nullable |                            Default
+-- -----------------------------+--------------------------+-----------+----------+---------------------------------------------------------------
+--  id                          | integer                  |           | not null | nextval('ocp_shared_cluster_configurations_id_seq'::regclass)
+--  name                        | character varying(255)   |           | not null |
+--  api_url                     | character varying(255)   |           | not null |
+--  kubeconfig                  | bytea                    |           |          |
+--  ingress_domain              | character varying(255)   |           | not null |
+--  additional_vars             | jsonb                    |           | not null | '{}'::jsonb
+--  created_at                  | timestamp with time zone |           | not null | (now() AT TIME ZONE 'utc'::text)
+--  updated_at                  | timestamp with time zone |           | not null | (now() AT TIME ZONE 'utc'::text)
+--  annotations                 | jsonb                    |           | not null | '{}'::jsonb
+--  valid                       | boolean                  |           | not null | true
+--  token                       | bytea                    |           |          |
+--  max_memory_usage_percentage | real                     |           |          | 90
+--  max_cpu_usage_percentage    | real                     |           |          | 100
+-- Indexes:
+--     "ocp_shared_cluster_configurations_pkey" PRIMARY KEY, btree (id)
+--     "ocp_shared_cluster_configurations_api_url_idx" btree (api_url)
+--     "ocp_shared_cluster_configurations_name_key" UNIQUE CONSTRAINT, btree (name)
+-- Triggers:
+--     ocp_shared_cluster_configurations_updated_at BEFORE UPDATE ON ocp_shared_cluster_configurations FOR EACH ROW WHEN (old.* IS DISTINCT FROM new.*) EXECUTE FUNCTION updated_at_column()
+
+BEGIN;
+
+-- Add a default_sandbox_quota column of type jsonb to the ocp_shared_cluster_configurations table
+-- not null
+-- default value : '{}'
+ALTER TABLE ocp_shared_cluster_configurations
+  ADD COLUMN default_sandbox_quota jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+-- Add a strict_default_sandbox_quota column of type boolean to the ocp_shared_cluster_configurations table
+
+ALTER TABLE ocp_shared_cluster_configurations
+  ADD COLUMN strict_default_sandbox_quota boolean NOT NULL DEFAULT false;
+
+-- Add a quota_required boolean column to the ocp_shared_cluster_configurations table
+ALTER TABLE ocp_shared_cluster_configurations
+  ADD COLUMN quota_required boolean NOT NULL DEFAULT false;
+
+COMMIT;

--- a/db/migrations/011_quota.up.sql
+++ b/db/migrations/011_quota.up.sql
@@ -38,4 +38,8 @@ ALTER TABLE ocp_shared_cluster_configurations
 ALTER TABLE ocp_shared_cluster_configurations
   ADD COLUMN quota_required boolean NOT NULL DEFAULT false;
 
+-- Add a skip_quota boolean column to the ocp_shared_cluster_configurations table
+ALTER TABLE ocp_shared_cluster_configurations
+  ADD COLUMN skip_quota boolean NOT NULL DEFAULT false;
+
 COMMIT;

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1558,8 +1558,81 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /ocp-shared-cluster-configurations/{name}/update:
+    put:
+      summary: Update quota conf for an OcpSharedClusterConfiguration
+      operationId: updateOcpSharedClusterConfiguration
+      tags:
+        - admin
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the OcpSharedClusterConfiguration changes
+          schema:
+            type: string
+            example: ocp-cluster-1
+      requestBody:
+        description: JSON object to specify the OcpSharedClusterConfiguration.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                strict_default_sandbox_quota:
+                  type: boolean
+                  description: |-
+                    StrictDefaultSandboxQuota is a flag to determine if the default sandbox quota should be strictly enforced. If set to true, the default sandbox quota will be enforced as a hard limit. Requested quota not be allowed to exceed the default. By default it's false.
+                quota_required:
+                  type: boolean
+                  description: |-
+                    QuotaRequired is a flag to determine if a quota is required in any request for an OcpSandbox. If set to true, a quota must be provided in the request. If set to false, a quota will be created based on the default sandbox quota. By default it's false.
+                quota:
+                  type: object
+                  description: |
+                    Quota to be applied to the namespace of the OcpSandbox
+                    The way quota is applied depends on the OcpSharedClusterConfiguration.
+                    By default, if a quota value is missing, the default quota of the shared cluster is applied instead.
 
-
+            example:
+              strict_default_sandbox_quota: true
+              quota_required: true
+              max_memory_usage_percentage: 70
+              max_cpu_usage_percentage: 80
+              token: '...'
+              additional_vars:
+                fordeployer: '...'
+              annotations:
+                virt: available
+                cloud: ibm
+                purpose: dev
+              default_sandbox_quota:
+                pods: "12"
+                requests.memory: "20Gi"
+                limits.memory: "20Gi"
+                secrets: "2"
+                requests.ephemeral-storage: "100Gi"
+      responses:
+        '200':
+          description: The OcpSharedClusterConfiguration is updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Message"
+              example:
+                message: OCP shared cluster configuration updated
+        '404':
+          description: updateOcpSharedClusterConfiguration OcpSharedClusterConfiguration not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: updateOcpSharedClusterConfiguration unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /health:
     get:
       summary: Health endpoint
@@ -1636,6 +1709,26 @@ components:
                 $ref: "#/components/schemas/Annotations"
               annotations:
                 $ref: "#/components/schemas/Annotations"
+              quota:
+                type: object
+                description: |
+                  Quota to be applied to the namespace of the OcpSandbox
+                  The way quota is applied depends on the OcpSharedClusterConfiguration.
+                  By default, if a quota value is missing, the default quota of the shared cluster is applied instead.
+
+                  StrictDefaultSandboxQuota is a flag to determine if the default sandbox quota should be strictly enforced. If set to true, the default sandbox quota will be enforced as a hard limit. Requested quota not be allowed to exceed the default. By default it's false.
+
+                  If set to false, the default sandbox will be updated to the requested quota.
+                  QuotaRequired is a flag to determine if a quota is required in any request for an OcpSandbox.
+                  If set to true, a quota must be provided in the request.
+                  If set to false, a quota will be created based on the default sandbox quota.
+                  By default it's false.
+                example:
+                  pods: "12"
+                  requests.memory: "20Gi"
+                  limits.memory: "20Gi"
+                  secrets: "2"
+                  requests.ephemeral-storage: "100Gi"
         annotations:
           $ref: "#/components/schemas/Annotations"
       example:
@@ -2175,6 +2268,53 @@ components:
           description: The maximum CPU usage percentage for a cluster to be considered healthy
           example: 80
           default: 100
+        default_sandbox_quota:
+          type: object
+          description: |-
+            The default quota for namespaces for sandboxes in the cluster
+            type is ResourceQuota from k8s.io/api/core/v1
+          default:
+            apiVersion: v1
+            kind: ResourceQuota
+            metadata:
+              name: sandbox-quota
+            spec:
+              hard:
+                pods: "10"
+                limits.cpu: "10"
+                limits.memory: "20Gi"
+                requests.cpu: "10"
+                requests.memory: "20Gi"
+                requests.storage: "50Gi"
+                requests.ephemeral-storage: "50Gi"
+                limits.ephemeral-storage: "50Gi"
+                persistentvolumeclaims: "10"
+                services: "10"
+                services.loadbalancers: "10"
+                services.nodeports: "10"
+                secrets: "10"
+                configmaps: "10"
+                replicationcontrollers: "10"
+                resourcequotas: "10"
+        strict_default_sandbox_quota:
+          type: boolean
+          description: |-
+            StrictDefaultSandboxQuota is a flag to determine if the default sandbox quota
+            should be strictly enforced. If set to true, the default sandbox quota will be
+            enforced as a hard limit. Requested quota not be allowed to exceed the default.
+            If set to false, the default sandbox will be updated
+            to the requested quota.
+          default: false
+        quota_required:
+          type: boolean
+          description: |-
+            QuotaRequired is a flag to determine if a quota is required for
+            a shared Cluster.
+            If set to true, a quota will be required in the request for a
+            Sandbox, usually set in agnosticV.
+            If set to false, a quota will not be required and the default quota
+            will apply.
+          default: false
       example:
         name: ocp-cluster-1
         api_url: https://api.ocp-cluster-1.com:6443

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1578,6 +1578,7 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 strict_default_sandbox_quota:
                   type: boolean
@@ -1587,16 +1588,35 @@ paths:
                   type: boolean
                   description: |-
                     QuotaRequired is a flag to determine if a quota is required in any request for an OcpSandbox. If set to true, a quota must be provided in the request. If set to false, a quota will be created based on the default sandbox quota. By default it's false.
-                quota:
+                default_sandbox_quota:
                   type: object
                   description: |
                     Quota to be applied to the namespace of the OcpSandbox
                     The way quota is applied depends on the OcpSharedClusterConfiguration.
                     By default, if a quota value is missing, the default quota of the shared cluster is applied instead.
-
+                skip_quota:
+                  type: boolean
+                  description: |-
+                    SkipQuota is a flag to control if the sandbox quota should be disabled.
+                    If set to true, the sandbox quota will not be created.
+                    If set to false, the sandbox quota will be created, depending on the value of quota_required, default_sandbox_quota and strict_default_sandbox_quota.
+                    By default it's true.
+                max_memory_usage_percentage:
+                  type: number
+                  format: float
+                max_cpu_usage_percentage:
+                  type: number
+                  format: float
+                token:
+                  type: string
+                annotations:
+                  $ref: "#/components/schemas/Annotations"
+                additional_vars:
+                  type: object
             example:
               strict_default_sandbox_quota: true
               quota_required: true
+              skip_quota: false
               max_memory_usage_percentage: 70
               max_cpu_usage_percentage: 80
               token: '...'
@@ -1746,6 +1766,7 @@ components:
       example:
         guid: abcde
         env_type: ocp4-cluster
+        hcp: "yes"
 
     Placement:
       type: object
@@ -2209,6 +2230,7 @@ components:
         - api_url
         - ingress_domain
         - annotations
+      additionalProperties: false
       properties:
         name:
           type: string
@@ -2315,6 +2337,14 @@ components:
             If set to false, a quota will not be required and the default quota
             will apply.
           default: false
+        skip_quota:
+          type: boolean
+          description: |-
+            SkipQuota is a flag to control if the sandbox quota should be disabled.
+            If set to true, the sandbox quota will not be created.
+            If set to false, the sandbox quota will be created, depending on the value of
+            quota_required, default_sandbox_quota and strict_default_sandbox_quota.
+          default: true
       example:
         name: ocp-cluster-1
         api_url: https://api.ocp-cluster-1.com:6443

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -168,6 +168,7 @@ type UpdateOcpSharedConfigurationRequest struct {
 	DefaultSandboxQuota       *v1.ResourceQuota   `json:"default_sandbox_quota,omitempty"`
 	QuotaRequired             *bool               `json:"quota_required"`
 	StrictDefaultSandboxQuota *bool               `json:"strict_default_sandbox_quota"`
+	SkipQuota                 *bool               `json:"skip_quota,omitempty"`
 	Annotations               *models.Annotations `json:"annotations,omitempty"`
 	Token                     *string             `json:"token,omitempty"`
 	AdditionalVars            map[string]any      `json:"additional_vars,omitempty"`

--- a/internal/dynamodb/accounts.go
+++ b/internal/dynamodb/accounts.go
@@ -124,7 +124,7 @@ func makeAccount(account AwsAccountDynamoDB) models.AwsAccount {
 
 	ti, err := strconv.ParseInt(strconv.FormatFloat(account.UpdateTime, 'f', 0, 64), 10, 64)
 	if err != nil {
-		log.Logger.Error("Got error parsing update time:", err)
+		log.Logger.Error("Got error parsing update time:", "error", err)
 	}
 
 	a.UpdatedAt = time.Unix(ti, 0)
@@ -240,7 +240,7 @@ func GetAccount(svc *dynamodb.DynamoDB, name string) (AwsAccountDynamoDB, error)
 			log.Logger.Error(errget.Error())
 		}
 
-		log.Logger.Error("errget", errget)
+		log.Logger.Error("error", "error", errget)
 		return AwsAccountDynamoDB{}, errget
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,9 +13,10 @@ type Model struct {
 type Resource struct {
 	Model
 
-	ServiceUuid string `json:"service_uuid"`
-	Available   bool   `json:"available"`
-	ToCleanup   bool   `json:"to_cleanup"`
+	ServiceUuid  string `json:"service_uuid"`
+	Available    bool   `json:"available"`
+	ToCleanup    bool   `json:"to_cleanup"`
+	ErrorMessage string `json:"error_message,omitempty"`
 
 	Annotations Annotations `json:"annotations"`
 }

--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rhpds/sandbox/internal/log"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -43,6 +44,26 @@ type OcpSharedClusterConfiguration struct {
 	MaxCpuUsagePercentage    float64           `json:"max_cpu_usage_percentage"`
 	DbPool                   *pgxpool.Pool     `json:"-"`
 	VaultSecret              string            `json:"-"`
+	// For any new project (openshift namespace) created by the sandbox API
+	// for an OcpSandbox, a default ResourceQuota will be set.
+	// This quota is designed to be large enough to accommodate general needs.
+	// Additionally, content developers can specify custom quotas in agnosticV
+	// based on the requirements of specific Labs/Demos.
+	DefaultSandboxQuota *v1.ResourceQuota `json:"default_sandbox_quota"`
+
+	// StrictDefaultSandboxQuota is a flag to determine if the default sandbox quota
+	// should be strictly enforced. If set to true, the default sandbox quota will be
+	// enforced as a hard limit. Requested quota not be allowed to exceed the default.
+	// If set to false, the default sandbox will be updated
+	// to the requested quota.
+	StrictDefaultSandboxQuota bool `json:"strict_default_sandbox_quota"`
+
+	// QuotaRequired is a flag to determine if a quota is required in any request
+	// for an OcpSandbox.
+	// If set to true, a quota must be provided in the request.
+	// If set to false, a quota will be created based on the default sandbox quota.
+	// By default it's false.
+	QuotaRequired bool `json:"quota_required"`
 }
 
 type OcpSharedClusterConfigurations []OcpSharedClusterConfiguration
@@ -57,10 +78,12 @@ type OcpSandbox struct {
 	OcpApiUrl                         string            `json:"api_url"`
 	Annotations                       map[string]string `json:"annotations"`
 	Status                            string            `json:"status"`
+	ErrorMessage                      string            `json:"error_message,omitempty"`
 	CleanupCount                      int               `json:"cleanup_count"`
 	Namespace                         string            `json:"namespace"`
 	ClusterAdditionalVars             map[string]any    `json:"cluster_additional_vars,omitempty"`
 	ToCleanup                         bool              `json:"to_cleanup"`
+	Quota                             v1.ResourceList   `json:"quota,omitempty"`
 }
 
 type OcpSandboxWithCreds struct {
@@ -84,6 +107,46 @@ type TokenResponse struct {
 }
 
 var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
+// MakeOcpSharedClusterConfiguration creates a new OcpSharedClusterConfiguration
+// with default values
+func MakeOcpSharedClusterConfiguration() *OcpSharedClusterConfiguration {
+	p := &OcpSharedClusterConfiguration{}
+
+	p.Valid = true
+	p.MaxMemoryUsagePercentage = 80
+	p.MaxCpuUsagePercentage = 100
+	p.DefaultSandboxQuota = &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sandbox-quota",
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourcePods:                     resource.MustParse("10"),
+				v1.ResourceLimitsCPU:                resource.MustParse("10"),
+				v1.ResourceLimitsMemory:             resource.MustParse("20Gi"),
+				v1.ResourceRequestsCPU:              resource.MustParse("10"),
+				v1.ResourceRequestsMemory:           resource.MustParse("20Gi"),
+				v1.ResourceRequestsStorage:          resource.MustParse("50Gi"),
+				v1.ResourceEphemeralStorage:         resource.MustParse("50Gi"),
+				v1.ResourceRequestsEphemeralStorage: resource.MustParse("50Gi"),
+				v1.ResourceLimitsEphemeralStorage:   resource.MustParse("50Gi"),
+				v1.ResourcePersistentVolumeClaims:   resource.MustParse("10"),
+				v1.ResourceServices:                 resource.MustParse("10"),
+				v1.ResourceServicesLoadBalancers:    resource.MustParse("10"),
+				v1.ResourceServicesNodePorts:        resource.MustParse("10"),
+				v1.ResourceSecrets:                  resource.MustParse("10"),
+				v1.ResourceConfigMaps:               resource.MustParse("10"),
+				v1.ResourceReplicationControllers:   resource.MustParse("10"),
+				v1.ResourceQuotas:                   resource.MustParse("10"),
+			},
+		},
+	}
+	p.StrictDefaultSandboxQuota = false
+	p.QuotaRequired = false
+
+	return p
+}
 
 // Bind and Render
 func (p *OcpSharedClusterConfiguration) Bind(r *http.Request) error {
@@ -124,17 +187,6 @@ func (p *OcpSharedClusterConfiguration) Bind(r *http.Request) error {
 		return errors.New("max_cpu_usage_percentage must be between 0 and 100")
 	}
 
-	// Set default values for CPU and Memory usage
-	if p.MaxMemoryUsagePercentage == 0 {
-		p.MaxMemoryUsagePercentage = 90
-	}
-
-	if p.MaxCpuUsagePercentage == 0 {
-		p.MaxCpuUsagePercentage = 100
-	}
-
-	p.Valid = true
-
 	return nil
 }
 
@@ -165,8 +217,11 @@ func (p *OcpSharedClusterConfiguration) Save() error {
 			valid,
 			additional_vars,
 			max_memory_usage_percentage,
-			max_cpu_usage_percentage)
-			VALUES ($1, $2, $3, pgp_sym_encrypt($4::text, $5), pgp_sym_encrypt($6::text, $5), $7, $8, $9, $10, $11)
+			max_cpu_usage_percentage,
+			default_sandbox_quota,
+			strict_default_sandbox_quota,
+			quota_required)
+			VALUES ($1, $2, $3, pgp_sym_encrypt($4::text, $5), pgp_sym_encrypt($6::text, $5), $7, $8, $9, $10, $11, $12, $13, $14)
 			RETURNING id`,
 		p.Name,
 		p.ApiUrl,
@@ -179,6 +234,9 @@ func (p *OcpSharedClusterConfiguration) Save() error {
 		p.AdditionalVars,
 		p.MaxMemoryUsagePercentage,
 		p.MaxCpuUsagePercentage,
+		p.DefaultSandboxQuota,
+		p.StrictDefaultSandboxQuota,
+		p.QuotaRequired,
 	).Scan(&p.ID); err != nil {
 		return err
 	}
@@ -203,7 +261,10 @@ func (p *OcpSharedClusterConfiguration) Update() error {
 			 valid = $8,
 			 additional_vars = $9,
 			 max_memory_usage_percentage = $11,
-			 max_cpu_usage_percentage = $12
+			 max_cpu_usage_percentage = $12,
+			 default_sandbox_quota = $13,
+			 strict_default_sandbox_quota = $14,
+			 quota_required = $15
 		 WHERE id = $10`,
 		p.Name,
 		p.ApiUrl,
@@ -217,6 +278,9 @@ func (p *OcpSharedClusterConfiguration) Update() error {
 		p.ID,
 		p.MaxMemoryUsagePercentage,
 		p.MaxCpuUsagePercentage,
+		p.DefaultSandboxQuota,
+		p.StrictDefaultSandboxQuota,
+		p.QuotaRequired,
 	); err != nil {
 		return err
 	}
@@ -279,7 +343,10 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurationByName(name string)
 			valid,
 			additional_vars,
 			max_memory_usage_percentage,
-			max_cpu_usage_percentage
+			max_cpu_usage_percentage,
+			default_sandbox_quota,
+			strict_default_sandbox_quota,
+			quota_required
 		 FROM ocp_shared_cluster_configurations WHERE name = $2`,
 		p.VaultSecret, name,
 	)
@@ -299,6 +366,9 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurationByName(name string)
 		&cluster.AdditionalVars,
 		&cluster.MaxMemoryUsagePercentage,
 		&cluster.MaxCpuUsagePercentage,
+		&cluster.DefaultSandboxQuota,
+		&cluster.StrictDefaultSandboxQuota,
+		&cluster.QuotaRequired,
 	); err != nil {
 		return OcpSharedClusterConfiguration{}, err
 	}
@@ -327,7 +397,10 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurations() (OcpSharedClust
 			valid,
 			additional_vars,
 			max_memory_usage_percentage,
-			max_cpu_usage_percentage
+			max_cpu_usage_percentage,
+			default_sandbox_quota,
+			strict_default_sandbox_quota,
+			quota_required
 		 FROM ocp_shared_cluster_configurations`,
 		p.VaultSecret,
 	)
@@ -356,6 +429,9 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurations() (OcpSharedClust
 			&cluster.AdditionalVars,
 			&cluster.MaxMemoryUsagePercentage,
 			&cluster.MaxCpuUsagePercentage,
+			&cluster.DefaultSandboxQuota,
+			&cluster.StrictDefaultSandboxQuota,
+			&cluster.QuotaRequired,
 		); err != nil {
 			return []OcpSharedClusterConfiguration{}, err
 		}
@@ -740,7 +816,7 @@ func anySchedulableNodes(nodes []v1.Node) bool {
 	return false
 }
 
-func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[string]string, annotations map[string]string, multiple bool, ctx context.Context) (OcpSandboxWithCreds, error) {
+func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[string]string, annotations map[string]string, requestedQuota *v1.ResourceList, multiple bool, ctx context.Context) (OcpSandboxWithCreds, error) {
 	var selectedCluster OcpSharedClusterConfiguration
 
 	// Ensure annotation has guid
@@ -899,6 +975,7 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 
 		rnew.OcpApiUrl = selectedCluster.ApiUrl
 		rnew.OcpSharedClusterConfigurationName = selectedCluster.Name
+		rnew.OcpIngressDomain = selectedCluster.IngressDomain
 
 		if err := rnew.Save(); err != nil {
 			log.Logger.Error("Error saving OCP account", "error", err)
@@ -931,6 +1008,7 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 		namespaceName = namespaceName[:min(63, len(namespaceName))] // truncate to 63
 
 		delay := time.Second
+		// Loop to wait for the namespace to be deleted
 		for {
 			// Create the Namespace
 			// Add serviceUuid as label to the namespace
@@ -972,6 +1050,58 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 				return
 			}
 			break
+		}
+
+		// Create Quota for the Namespace
+		// First calculate the quota using the requested_quota from the PlacementRequest and
+		// the options from the OcpSharedClusterConfiguration
+		requested := &v1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sandbox-requested-quota",
+			},
+			Spec: v1.ResourceQuotaSpec{
+				Hard: *requestedQuota,
+			},
+		}
+
+		if selectedCluster.QuotaRequired {
+			// Check if the requested quota is provided and not empty
+			if requestedQuota == nil || len(*requestedQuota) == 0 {
+				log.Logger.Error("Error creating OCP quota", "error", "requested quota is required")
+				rnew.ErrorMessage = "Quota is required for this cluster and should be specified in the request"
+				if err := rnew.Save(); err != nil {
+					log.Logger.Error("Error saving OCP account", "error", err)
+				}
+				rnew.SetStatus("error")
+				return
+			}
+		}
+
+		quota := ApplyQuota(requested,
+			selectedCluster.DefaultSandboxQuota,
+			selectedCluster.StrictDefaultSandboxQuota,
+		)
+
+		rnew.Quota = quota.Spec.Hard
+
+		// Troubleshooting output the quota
+		log.Logger.Debug("Quota", "quota", quota, "selectedCluster", selectedCluster,
+			"requestedQuota", requestedQuota)
+
+		if err := rnew.Save(); err != nil {
+			log.Logger.Error("Error saving OCP account", "error", err)
+			rnew.SetStatus("error")
+			return
+		}
+
+		_, err = clientset.CoreV1().ResourceQuotas(namespaceName).Create(context.TODO(), quota, metav1.CreateOptions{})
+		if err != nil {
+			log.Logger.Error("Error creating OCP quota", "error", err)
+			if err := clientset.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, metav1.DeleteOptions{}); err != nil {
+				log.Logger.Error("Error cleaning up the namespace", "error", err)
+			}
+			rnew.SetStatus("error")
+			return
 		}
 
 		_, err = clientset.CoreV1().ServiceAccounts(namespaceName).Create(context.TODO(), &v1.ServiceAccount{
@@ -1135,33 +1265,18 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 				Token: string(saSecret.Data["token"]),
 			},
 		}
-		r := OcpSandboxWithCreds{
-			OcpSandbox: OcpSandbox{
-				Name:                              rnew.Name,
-				Kind:                              "OcpSandbox",
-				OcpSharedClusterConfigurationName: selectedCluster.Name,
-				OcpApiUrl:                         selectedCluster.ApiUrl,
-				OcpIngressDomain:                  selectedCluster.IngressDomain,
-				Annotations:                       annotations,
-				ServiceUuid:                       serviceUuid,
-				Status:                            "success",
-				Namespace:                         namespaceName,
-			},
-			Credentials: creds,
-			Provider:    a,
-		}
+		rnew.Credentials = creds
+		rnew.Status = "success"
 
-		r.ID = rnew.ID
-
-		if err := r.Save(); err != nil {
+		if err := rnew.Save(); err != nil {
 			log.Logger.Error("Error saving OCP account", "error", err)
 			log.Logger.Info("Trying to cleanup OCP account")
-			if err := r.Delete(); err != nil {
+			if err := rnew.Delete(); err != nil {
 				log.Logger.Error("Error cleaning up OCP account", "error", err)
 			}
 		}
-		log.Logger.Info("Ocp sandbox booked", "account", r.Name, "service_uuid", r.ServiceUuid,
-			"cluster", r.OcpSharedClusterConfigurationName, "namespace", r.Namespace)
+		log.Logger.Info("Ocp sandbox booked", "account", rnew.Name, "service_uuid", rnew.ServiceUuid,
+			"cluster", rnew.OcpSharedClusterConfigurationName, "namespace", rnew.Namespace)
 	}()
 	//--------------------------------------------------
 
@@ -1304,6 +1419,11 @@ func (account *OcpSandboxWithCreds) Delete() error {
 	for {
 		status, err := account.GetStatus()
 		if err != nil {
+			// if norow, the resource was not created, nothing to delete
+			if err == pgx.ErrNoRows {
+				log.Logger.Info("Resource not found", "name", account.Name)
+				return nil
+			}
 			log.Logger.Error("cannot get status of resource", "error", err, "name", account.Name)
 			break
 		}
@@ -1406,8 +1526,6 @@ func (account *OcpSandboxWithCreds) Delete() error {
 		account.SetStatus("error")
 		return err
 	}
-	// Define the Service Account name
-	serviceAccountName := "sandbox"
 
 	// Check if the namespace exists
 	_, err = clientset.CoreV1().Namespaces().Get(context.TODO(), account.Namespace, metav1.GetOptions{})
@@ -1440,15 +1558,6 @@ func (account *OcpSandboxWithCreds) Delete() error {
 		"namespace", account.Namespace,
 		"cluster", account.OcpSharedClusterConfigurationName,
 	)
-
-	// Delete the Service Account
-	if err = clientset.CoreV1().
-		ServiceAccounts(account.Namespace).
-		Delete(context.TODO(), serviceAccountName, metav1.DeleteOptions{}); err != nil {
-		log.Logger.Error("Error deleting OCP service account", "error", err)
-		account.SetStatus("error")
-		return err
-	}
 
 	rbName := "allow-clone-" + account.Namespace[:min(51, len(account.Namespace))]
 	// Delete the role binding from the cnv-images namespace
@@ -1600,4 +1709,85 @@ func (a *OcpSandboxWithCreds) Reload() error {
 	}
 
 	return nil
+}
+
+func ApplyQuota(requestedQuotaOrig *v1.ResourceQuota, defaultQuota *v1.ResourceQuota, strictDefaultSandboxQuota bool) *v1.ResourceQuota {
+	var resultQuota *v1.ResourceQuota
+
+	if requestedQuotaOrig == nil {
+		return defaultQuota
+	}
+	// deepcopy the default quota
+	resultQuota = defaultQuota.DeepCopy()
+	requestedQuota := requestedQuotaOrig.DeepCopy()
+
+	// If strictDefaultSandboxQuota is true, the default quota cannot be exceeded.
+	// lower values are updated though
+
+	// first, iterate over the requested quota to check for new keys like:
+	// <storage-class-name>.storageclass.storage.k8s.io/requests.storage
+	// or the aliases:  cpu / memory / storage / ephemeral-storage
+	// which should translate to:
+	// requests.cpu / requests.memory / requests.storage / requests.ephemeral-storage
+	for key, item := range requestedQuota.Spec.Hard {
+		if _, exists := defaultQuota.Spec.Hard[key]; !exists {
+			// if the key is one of 'cpu', 'memory', 'ephemeral-storage'
+			// add it as 'requests.<key>'
+			switch key {
+			case "cpu":
+				// check if the key 'requests.cpu' already exists in the requested quota (duplicate)
+				// if it does, take the minimum
+				if requested, exists := requestedQuota.Spec.Hard[v1.ResourceRequestsCPU]; exists {
+					if item.Cmp(requested) < 0 {
+						requestedQuota.Spec.Hard[v1.ResourceRequestsCPU] = item.DeepCopy()
+					}
+				} else {
+					requestedQuota.Spec.Hard[v1.ResourceRequestsCPU] = item.DeepCopy()
+				}
+
+				delete(requestedQuota.Spec.Hard, key)
+			case "memory":
+				// check if the key 'requests.memory' already exists in the requested quota (duplicate)
+				// if it does, take the minimum
+				if requested, exists := requestedQuota.Spec.Hard[v1.ResourceRequestsMemory]; exists {
+					if item.Cmp(requested) < 0 {
+						requestedQuota.Spec.Hard[v1.ResourceRequestsMemory] = item.DeepCopy()
+					}
+				} else {
+					requestedQuota.Spec.Hard[v1.ResourceRequestsMemory] = item.DeepCopy()
+				}
+
+				delete(requestedQuota.Spec.Hard, key)
+			case "ephemeral-storage":
+				// check if the key 'requests.ephemeral-storage' already exists in the requested quota (duplicate)
+				// if it does, take the minimum
+				if requested, exists := requestedQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage]; exists {
+					if item.Cmp(requested) < 0 {
+						requestedQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage] = item.DeepCopy()
+					}
+				} else {
+					requestedQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage] = item.DeepCopy()
+				}
+				delete(requestedQuota.Spec.Hard, key)
+			default:
+				// The key doesn't exist in the default quota, add it to the result
+				resultQuota.Spec.Hard[key] = item.DeepCopy()
+			}
+		}
+	}
+
+	// Now iterate over the main keys
+	for key, item := range resultQuota.Spec.Hard {
+		if requested, exists := requestedQuota.Spec.Hard[key]; exists {
+			if item.Cmp(requested) < 0 {
+				if !strictDefaultSandboxQuota {
+					resultQuota.Spec.Hard[key] = requested.DeepCopy()
+				}
+			} else {
+				resultQuota.Spec.Hard[key] = requested.DeepCopy()
+			}
+		}
+	}
+
+	return resultQuota
 }

--- a/internal/models/ocp_sandbox_test.go
+++ b/internal/models/ocp_sandbox_test.go
@@ -1,0 +1,289 @@
+package models
+
+import (
+	"testing"
+	// json
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestApplyQuota(t *testing.T) {
+	defaultQuota := &v1.ResourceQuota{
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	requestedQuota := &v1.ResourceQuota{
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
+	}
+
+	// Test strictDefaultSandboxQuota is true
+	resultQuota := ApplyQuota(requestedQuota, defaultQuota, true)
+
+	cpu, _ := resultQuota.Spec.Hard[v1.ResourceCPU]
+	if cpu.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("CPU quota should be 1, got %s", cpu.String())
+	}
+
+	memory, _ := resultQuota.Spec.Hard[v1.ResourceMemory]
+	if memory.Cmp(resource.MustParse("1Gi")) != 0 {
+		t.Errorf("Memory quota should be 1Gi, got %s", memory.String())
+	}
+
+	// Test strictDefaultSandboxQuota is false
+	resultQuota = ApplyQuota(requestedQuota, defaultQuota, false)
+
+	cpu, _ = resultQuota.Spec.Hard[v1.ResourceCPU]
+	if cpu.Cmp(resource.MustParse("2")) != 0 {
+		t.Logf("%v", resultQuota.Spec.Hard)
+		t.Errorf("CPU quota should be 2, got %s", cpu.String())
+	}
+
+	memory, _ = resultQuota.Spec.Hard[v1.ResourceMemory]
+	if memory.Cmp(resource.MustParse("2Gi")) != 0 {
+		t.Errorf("Memory quota should be 2Gi, got %s", memory.String())
+	}
+
+	// Now do more complex tests using JSON unmarshalling
+	jsonQuota := []byte(`{
+		"spec": {
+			"hard": {
+				"cpu": "3",
+				"memory": "3Gi"
+			}
+		}
+	}`)
+
+	requestedQuota.Reset()
+
+	if err := json.Unmarshal(jsonQuota, requestedQuota); err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+
+	defaultJsonQuota := []byte(`{
+		"spec": {
+			"hard": {
+				"cpu": "1",
+				"memory": "1Gi"
+			}
+		}
+	}`)
+
+	defaultQuota.Reset()
+
+	if err := json.Unmarshal(defaultJsonQuota, defaultQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	resultQuota = ApplyQuota(requestedQuota, defaultQuota, true)
+
+	cpu, _ = resultQuota.Spec.Hard[v1.ResourceCPU]
+	if cpu.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("CPU quota should be 1, got %s", cpu.String())
+	}
+
+	memory, _ = resultQuota.Spec.Hard[v1.ResourceMemory]
+	if memory.Cmp(resource.MustParse("1Gi")) != 0 {
+		t.Errorf("Memory quota should be 1Gi, got %s", memory.String())
+	}
+
+	jsonDefaultQuota := []byte(`{
+        "apiVersion": "v1",
+		"kind": "ResourceQuota",
+		"metadata": {
+			"name": "sandbox-quota"
+		},
+		"spec": {
+			"hard": {
+				"pods": "10",
+				"limits.cpu": "10",
+				"limits.memory": "20Gi",
+				"requests.cpu": "10",
+				"requests.memory": "10Gi",
+				"requests.storage": "50Gi",
+				"requests.ephemeral-storage": "50Gi",
+				"limits.ephemeral-storage": "50Gi",
+				"persistentvolumeclaims": "10",
+				"services": "10",
+				"services.loadbalancers": "10",
+				"services.nodeports": "10",
+				"secrets": "10",
+				"configmaps": "10",
+				"replicationcontrollers": "10",
+				"resourcequotas": "10"
+			}
+		}
+	}`)
+	defaultQuota.Reset()
+	if err := json.Unmarshal(jsonDefaultQuota, defaultQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	jsonRequestedQuota := []byte(`{
+        "apiVersion": "v1",
+		"kind": "ResourceQuota",
+		"metadata": {
+			"name": "requested"
+		},
+		"spec": {
+			"hard": {
+				"pods": "12",
+				"limits.memory": "10Gi",
+				"secrets": "2",
+				"requests.ephemeral-storage": "5000"
+			}
+		}
+	}`)
+
+	requestedQuota.Reset()
+	if err := json.Unmarshal(jsonRequestedQuota, requestedQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	resultQuota = ApplyQuota(requestedQuota, defaultQuota, true)
+
+	pods, _ := resultQuota.Spec.Hard[v1.ResourcePods]
+	if pods.Cmp(resource.MustParse("10")) != 0 {
+		t.Errorf("Pods quota should be 10, got %s", pods.String())
+	}
+
+	cpu, _ = resultQuota.Spec.Hard[v1.ResourceLimitsCPU]
+	if cpu.Cmp(resource.MustParse("10")) != 0 {
+		t.Errorf("CPU quota should be 10, got %s", cpu.String())
+	}
+
+	memory, _ = resultQuota.Spec.Hard[v1.ResourceLimitsMemory]
+	if memory.Cmp(resource.MustParse("10Gi")) != 0 {
+		t.Errorf("Memory quota should be 10Gi, got %s", memory.String())
+	}
+	replicationcontrollers, _ := resultQuota.Spec.Hard[v1.ResourceReplicationControllers]
+	if replicationcontrollers.Cmp(resource.MustParse("10")) != 0 {
+		t.Errorf("ReplicationControllers quota should be 10, got %s", replicationcontrollers.String())
+	}
+
+	ephemeralStorage, _ := resultQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage]
+	if ephemeralStorage.Cmp(resource.MustParse("5000")) != 0 {
+		t.Errorf("EphemeralStorage quota should be 5000, got %s", ephemeralStorage.String())
+	}
+
+	if resultQuota.Name != "sandbox-quota" {
+		t.Errorf("Name of the quota should be 'sandbox-quota', got %s", resultQuota.Name)
+	}
+
+	if err := json.Unmarshal(jsonRequestedQuota, requestedQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	// Ensure aliases work
+
+	jsonRequestedQuota = []byte(`{
+        "apiVersion": "v1",
+		"kind": "ResourceQuota",
+		"metadata": {
+			"name": "requested"
+		},
+		"spec": {
+			"hard": {
+				"ephemeral-storage": "5000",
+				"cpu": "100m",
+				"memory": "100",
+				"cnv.storageclass.storage.k8s.io/requests.storage": "50Gi"
+			}
+		}
+	}`)
+
+	requestedQuota.Reset()
+	if err := json.Unmarshal(jsonRequestedQuota, requestedQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	resultQuota = ApplyQuota(requestedQuota, defaultQuota, true)
+
+	ephemeralStorage, _ = resultQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage]
+	if ephemeralStorage.Cmp(resource.MustParse("5000")) != 0 {
+		t.Errorf("EphemeralStorage quota should be 5000, got %s", ephemeralStorage.String())
+	}
+
+	memory, _ = resultQuota.Spec.Hard[v1.ResourceRequestsMemory]
+	if memory.Cmp(resource.MustParse("100")) != 0 {
+		t.Errorf("Memory quota should be 100, got %s", memory.String())
+	}
+
+	cpu, _ = resultQuota.Spec.Hard[v1.ResourceRequestsCPU]
+	if cpu.Cmp(resource.MustParse("100m")) != 0 {
+		t.Errorf("CPU quota should be 100m, got %s", cpu.String())
+	}
+
+	cnvStorage, _ := resultQuota.Spec.Hard[v1.ResourceName("cnv.storageclass.storage.k8s.io/requests.storage")]
+	if cnvStorage.Cmp(resource.MustParse("50Gi")) != 0 {
+		t.Errorf("CNV Storage quota should be 50Gi, got %s", cnvStorage.String())
+	}
+
+	jsonRequestedQuota = []byte(`{
+        "apiVersion": "v1",
+		"kind": "ResourceQuota",
+		"metadata": {
+			"name": "requested"
+		},
+		"spec": {
+			"hard": {
+				"cpu": "100m",
+				"requests.cpu": "40m",
+				"memory": "2Gi",
+				"requests.memory": "100",
+				"ephemeral-storage": "1Gi",
+				"requests.ephemeral-storage": "0.1Gi"
+			}
+		}
+	}`)
+
+	requestedQuota.Reset()
+	if err := json.Unmarshal(jsonRequestedQuota, requestedQuota); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+	resultQuota = ApplyQuota(requestedQuota, defaultQuota, true)
+
+	cpu, _ = resultQuota.Spec.Hard[v1.ResourceRequestsCPU]
+	if cpu.Cmp(resource.MustParse("40m")) != 0 {
+		t.Errorf("CPU quota should be 100m, got %s", cpu.String())
+	}
+
+	memory, _ = resultQuota.Spec.Hard[v1.ResourceRequestsMemory]
+	if memory.Cmp(resource.MustParse("100")) != 0 {
+		t.Errorf("Memory quota should be 100, got %s", memory.String())
+	}
+
+	ephemeralStorage, _ = resultQuota.Spec.Hard[v1.ResourceRequestsEphemeralStorage]
+	if ephemeralStorage.Cmp(resource.MustParse("0.1Gi")) != 0 {
+		t.Errorf("EphemeralStorage quota should be 0.1Gi, got %s", ephemeralStorage.String())
+	}
+
+	// make sure 'cpu' doesn't exist
+	if _, ok := resultQuota.Spec.Hard[v1.ResourceCPU]; ok {
+		t.Errorf("CPU quota should not exist")
+	}
+
+	// test unmarshaling resourceList
+	jsonRequestedQuota = []byte(`{
+		"cpu": "100m",
+		"memory": "2Gi"
+	}`)
+
+	a := v1.ResourceList{}
+	if err := json.Unmarshal(jsonRequestedQuota, &a); err != nil {
+		t.Errorf("Error should be nil, got %s", err)
+	}
+
+}

--- a/internal/models/placements.go
+++ b/internal/models/placements.go
@@ -260,7 +260,7 @@ func (p *Placement) Delete(accountProvider AwsAccountProvider, ocpProvider OcpSa
 	}
 
 	if err := ocpProvider.Release(p.ServiceUuid); err != nil {
-		log.Logger.Error("Error while releasing OCP sandboxes")
+		log.Logger.Error("Error while releasing OCP sandboxes", "error", err)
 		p.SetStatus("error")
 		return
 	}

--- a/readme.adoc
+++ b/readme.adoc
@@ -136,9 +136,10 @@ make migrate  # Run the DB migrations to setup the db schema
 # Then this needs to match the one in use on the DEV environment
  export VAULT_SECRET=...
 
-make issue-jwt  # issue some JWT token for access
+make tokens # issue some JWT token for access
 make run-api # <1>
 air # <2>
+
 ----
 <1> When iterating, you will be stopping and relaunching this step
 <2> You can use link:https://github.com/cosmtrek/air[cosmtrek/air] instead. That will watch local files and rebuild + launch the API automatically if any changes are made.

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -99,6 +99,10 @@ HTTP 200
 jsonpath "$.name" == "ocp-cluster-test1"
 jsonpath "$.annotations.virt" == "no"
 jsonpath "$.valid" == true
+jsonpath "$.default_sandbox_quota.metadata.name" == "sandbox-quota"
+jsonpath "$.default_sandbox_quota.spec.hard['requests.memory']" == "20Gi"
+jsonpath "$.strict_default_sandbox_quota" == false
+jsonpath "$.quota_required" == false
 
 PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/disable
 Authorization: Bearer {{access_token_admin}}
@@ -128,6 +132,70 @@ HTTP 200
 jsonpath "$.name" == "ocp-cluster-test1"
 jsonpath "$.valid" == true
 
+# Update a bunch of parameters
+PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/update
+Authorization: Bearer {{ access_token_admin }}
+{
+  "quota_required": true,
+  "strict_default_sandbox_quota": true,
+  "max_memory_usage_percentage": 60
+
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration updated"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+HTTP 200
+[Asserts]
+jsonpath "$.strict_default_sandbox_quota" == true
+jsonpath "$.quota_required" == true
+jsonpath "$.max_memory_usage_percentage" == 60
+
+DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 2
+HTTP 404
+
+POST {{host}}/api/v1/ocp-shared-cluster-configurations
+Authorization: Bearer {{access_token_admin}}
+{
+    "name": "ocp-cluster-test1",
+    "api_url": "https://api.ocp-cluster-1.com:6443",
+    "ingress_domain": "apps.ocp-cluster-1.com",
+    "kubeconfig": "apiVersion: v1 ...",
+    "annotations": {
+        "virt": "no",
+        "cloud": "ibm",
+        "purpose": "dev"
+    },
+    "strict_default_sandbox_quota": true,
+    "quota_required": true,
+    "default_sandbox_quota": {
+        "metadata": {
+            "name": "sandbox-quota"
+        },
+        "spec": {
+            "hard": {
+                "requests.memory": "30Gi"
+            }
+        }
+    }
+}
+HTTP 201
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration created"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "ocp-cluster-test1"
+jsonpath "$.strict_default_sandbox_quota" == true
+jsonpath "$.quota_required" == true
+jsonpath "$.default_sandbox_quota.spec.hard['requests.memory']" == "30Gi"
 
 DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
 Authorization: Bearer {{access_token_admin}}
@@ -360,6 +428,8 @@ jsonpath "$.resources[0].ingress_domain" split "." count > 2
 jsonpath "$.resources[0].credentials" count >= 1
 jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
 jsonpath "$.resources[0].credentials[0].token" isString
+# Default quota should be applied
+jsonpath "$.resources[0].quota['requests.memory']" == "20Gi"
 
 #################################################################################
 # Create the same placement should return 409 conflict

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -64,6 +64,7 @@ Authorization: Bearer {{access_token_admin}}
     "api_url": "https://api.ocp-cluster-1.com:6443",
     "ingress_domain": "apps.ocp-cluster-1.com",
     "kubeconfig": "apiVersion: v1 ...",
+    "skip_quota": true,
     "annotations": {
         "virt": "no",
         "cloud": "ibm",
@@ -103,6 +104,7 @@ jsonpath "$.default_sandbox_quota.metadata.name" == "sandbox-quota"
 jsonpath "$.default_sandbox_quota.spec.hard['requests.memory']" == "20Gi"
 jsonpath "$.strict_default_sandbox_quota" == false
 jsonpath "$.quota_required" == false
+jsonpath "$.skip_quota" == true
 
 PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/disable
 Authorization: Bearer {{access_token_admin}}
@@ -138,8 +140,8 @@ Authorization: Bearer {{ access_token_admin }}
 {
   "quota_required": true,
   "strict_default_sandbox_quota": true,
-  "max_memory_usage_percentage": 60
-
+  "max_memory_usage_percentage": 60,
+  "skip_quota": false
 }
 HTTP 200
 [Asserts]
@@ -152,6 +154,7 @@ HTTP 200
 jsonpath "$.strict_default_sandbox_quota" == true
 jsonpath "$.quota_required" == true
 jsonpath "$.max_memory_usage_percentage" == 60
+jsonpath "$.skip_quota" == false
 
 DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
 Authorization: Bearer {{access_token_admin}}
@@ -428,8 +431,6 @@ jsonpath "$.resources[0].ingress_domain" split "." count > 2
 jsonpath "$.resources[0].credentials" count >= 1
 jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
 jsonpath "$.resources[0].credentials[0].token" isString
-# Default quota should be applied
-jsonpath "$.resources[0].quota['requests.memory']" == "20Gi"
 
 #################################################################################
 # Create the same placement should return 409 conflict
@@ -481,7 +482,6 @@ HTTP 200
 [Asserts]
 jsonpath "$.name" == "{{sandbox_name}}"
 jsonpath "$.service_uuid" == "{{uuid}}"
-
 
 #################################################################################
 # Delete placement

--- a/tests/003_ocp_quota.hurl
+++ b/tests/003_ocp_quota.hurl
@@ -1,0 +1,192 @@
+#################################################################################
+# Get an access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token}}
+HTTP 200
+[Captures]
+access_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Get an Admin access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token_admin}}
+HTTP 200
+[Captures]
+access_token_admin: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Ensure error when quota quantity doesn't match the k8s regex
+#################################################################################
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "quota": {
+        "requests.memory": "10Gixerror"
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "OcpSandbox placement with Quota with a wrong syntax",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-blablablabla"
+  }
+}
+HTTP 400
+[Asserts]
+jsonpath "$.error_multiline[0]" contains "quantities must match the regular expression"
+
+#################################################################################
+# Create a placement and specify a quota
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+        "quota": {
+            "requests.memory": "10Gi",
+            "cnv.storageclass.storage.k8s.io/requests.storage": "500Gi",
+            "requests.cpu": "40"
+        }
+    }
+  ],
+  "annotations": {
+    "tests": "OcpSandbox placement with a Quota",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-blablablabla"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+# Wait until the placement is succesfull and resources are ready
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Captures]
+testcluster: jsonpath "$.resources[0].ocp_cluster"
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].quota['requests.memory']" == "10Gi"
+jsonpath "$.resources[0].quota['requests.cpu']" == "40"
+jsonpath "$.resources[0].quota['cnv.storageclass.storage.k8s.io/requests.storage']" == "500Gi"
+
+# Delete placement
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Tests for quota_required
+#################################################################################
+
+# Update the OcpClusterConfiguration and set quota_required to true
+# Set quota_required to true
+PUT {{host}}/api/v1/ocp-shared-cluster-configurations/{{testcluster}}/update
+Authorization: Bearer {{ access_token_admin }}
+{
+  "quota_required": true
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration updated"
+
+# Create a placement and don't specify a quota
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{testcluster}}"
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "OcpSandbox placement missing Quota",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-blablablabla"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "error"
+jsonpath "$.resources[0].status" == "error"
+jsonpath "$.resources[0].error_message" contains "Quota is required for this cluster"
+
+# Update the OcpClusterConfiguration and set quota_required back to false
+
+PUT {{host}}/api/v1/ocp-shared-cluster-configurations/{{testcluster}}/update
+Authorization: Bearer {{ access_token_admin }}
+{
+  "quota_required": false
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration updated"
+
+#################################################################################
+# Delete placement
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404

--- a/tests/003_ocp_quota.hurl
+++ b/tests/003_ocp_quota.hurl
@@ -50,6 +50,69 @@ HTTP 400
 jsonpath "$.error_multiline[0]" contains "quantities must match the regular expression"
 
 #################################################################################
+# Create a new placement, check default quota is working
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox"
+    }
+  ],
+  "annotations": {
+    "tests": "Simple OcpSandbox placement",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-blablablabla"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+# Default quota should be applied
+jsonpath "$.resources[0].quota['requests.memory']" == "20Gi"
+
+#################################################################################
+# Delete placement
+#################################################################################
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
 # Create a placement and specify a quota
 #################################################################################
 

--- a/tests/003_ocp_quota.hurl
+++ b/tests/003_ocp_quota.hurl
@@ -25,6 +25,67 @@ jsonpath "$.access_token" isString
 jsonpath "$.access_token_exp" isString
 
 #################################################################################
+# Update default quota of an OcpSharedClusterConfiguration
+#################################################################################
+
+DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 2
+HTTP 404
+
+POST {{host}}/api/v1/ocp-shared-cluster-configurations
+Authorization: Bearer {{access_token_admin}}
+{
+    "name": "ocp-cluster-test1",
+    "api_url": "https://api.ocp-cluster-1.com:6443",
+    "ingress_domain": "apps.ocp-cluster-1.com",
+    "kubeconfig": "apiVersion: v1 ...",
+    "skip_quota": true,
+    "annotations": {
+        "virt": "no",
+        "cloud": "ibm",
+        "purpose": "dev"
+    }
+}
+HTTP 201
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration created"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+HTTP 200
+[Asserts]
+jsonpath "$.default_sandbox_quota.spec.hard['requests.memory']" == "20Gi"
+
+PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/update
+Authorization: Bearer {{ access_token_admin }}
+{
+  "default_sandbox_quota": {
+    "spec": {
+      "hard": {
+        "requests.memory": "700Gi"
+      }
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration updated"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+HTTP 200
+[Asserts]
+jsonpath "$.default_sandbox_quota.spec.hard['requests.memory']" == "700Gi"
+
+DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 2
+HTTP 404
+
+#################################################################################
 # Ensure error when quota quantity doesn't match the k8s regex
 #################################################################################
 POST {{host}}/api/v1/placements

--- a/tests/readme.adoc
+++ b/tests/readme.adoc
@@ -5,15 +5,19 @@ See link:https://hurl.dev/[hurl.dev] for upstream documentation.
 
 .Run local tests
 ----
-make run-api
-
+# The API must be running in another terminal
+make tokens
+. .dev.tokens_env
 uuid=$(uuidgen -r)
 
+cd tests/
+
 hurl --test \
-  --variable login_token=... \
-  --variable login_token_admin=... \
+  --variable login_token=$apptoken \
+  --variable login_token_admin=$admintoken \
   --variable host=http://localhost:8080 \
   --variable uuid=$uuid \
+  --jobs 1 \
   *.hurl
 ----
 
@@ -52,6 +56,7 @@ Either you're using the DEV database,  or you'll have to setup the OCP shared cl
     {
       "virt":"no",
       "cloud":"cnv",
+      "name": "cluster-foo",
       "purpose":"dev"
     },
   "kubeconfig": "..."


### PR DESCRIPTION
Following the design document and proposal, this changes implements the Quota for OcpSandbox.

OcpSharedClusterConfiguration is updated with the new fields:

```go
// For any new project (openshift namespace) created by the sandbox API
// for an OcpSandbox, a default ResourceQuota will be set.
// This quota is designed to be large enough to accommodate general needs.
// Additionally, content developers can specify custom quotas in agnosticV
// based on the requirements of specific Labs/Demos.
DefaultSandboxQuota *v1.ResourceQuota `json:"default_sandbox_quota"`

// StrictDefaultSandboxQuota is a flag to determine if the default sandbox quota
// should be strictly enforced. If set to true, the default sandbox quota will be
// enforced as a hard limit. Requested quota not be allowed to exceed the default.
// If set to false, the default sandbox will be updated
// to the requested quota.
StrictDefaultSandboxQuota bool `json:"strict_default_sandbox_quota"`

// QuotaRequired is a flag to determine if a quota is required in any request
// for an OcpSandbox.
// If set to true, a quota must be provided in the request.
// If set to false, a quota will be created based on the default sandbox quota.
// By default it's false.
QuotaRequired bool `json:"quota_required"`
```

In a nutshell:
* Add and update handlers
* Update openapi spec swagger file
* New DB migration
* Add unit tests for the (tricky) function that derives the quota from the default quota
* Add functional tests for the new feature(s)
* In Release() of the OcpSandbox, remove the part that tries to delete the service account. That is useless and can be removed. The service account is automatically deleted when the namespace is deleted.

Makefile:
- move CGO_ENABLED to the top of file (DRY)
- simplify running the test by creating a new target `make tokens`