### PR TITLE
OcpSandbox: Implement limit range

### DIFF
--- a/cmd/sandbox-api/handlers.go
+++ b/cmd/sandbox-api/handlers.go
@@ -180,6 +180,7 @@ func (h *BaseHandler) CreatePlacementHandler(w http.ResponseWriter, r *http.Requ
 				request.CloudSelector,
 				placementRequest.Annotations.Merge(request.Annotations),
 				request.Quota,
+				request.LimitRange,
 				multipleOcp,
 				r.Context(),
 			)

--- a/cmd/sandbox-api/ocp_shared_cluster_configuration_handlers.go
+++ b/cmd/sandbox-api/ocp_shared_cluster_configuration_handlers.go
@@ -311,6 +311,10 @@ func (h *BaseHandler) UpdateOcpSharedClusterConfigurationHandler(w http.Response
 		ocpSharedClusterConfiguration.SkipQuota = *input.SkipQuota
 	}
 
+	if input.LimitRange != nil {
+		ocpSharedClusterConfiguration.LimitRange = input.LimitRange
+	}
+
 	if err := ocpSharedClusterConfiguration.Save(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		render.Render(w, r, &v1.Error{

--- a/db/migrations/012_ocp_limit_range.down.sql
+++ b/db/migrations/012_ocp_limit_range.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- delete column limit_range from ocp_shared_cluster_configurations
+ALTER TABLE ocp_shared_cluster_configurations
+  DROP COLUMN limit_range;
+
+COMMIT;

--- a/db/migrations/012_ocp_limit_range.up.sql
+++ b/db/migrations/012_ocp_limit_range.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- Add a limit_range column to the ocp_shared_cluster_configurations table
+-- default should be json equivalent of
+--
+-- apiVersion: v1
+-- kind: LimitRange
+-- metadata:
+--   name: cpu-limit-range
+-- spec:
+--   limits:
+--   - default:
+--       cpu: 1
+--       memory: 2Gi
+--     defaultRequest:
+--       cpu: 0.5
+--       memory: 1Gi
+--     type: Container
+ALTER TABLE ocp_shared_cluster_configurations
+  ADD COLUMN limit_range jsonb NOT NULL DEFAULT '{"apiVersion": "v1", "kind": "LimitRange", "metadata": {"name": "sandbox-limit-range"}, "spec": {"limits": [{"default": {"cpu": "1", "memory": "2Gi"}, "defaultRequest": {"cpu": "0.5", "memory": "1Gi"}, "type": "Container"}]}}'::jsonb;
+
+
+COMMIT;

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1790,10 +1790,6 @@ components:
                   This allows to set the default limit and request for pods
                   see https://kubernetes.io/docs/concepts/policy/limit-range/
                 example:
-                  apiVersion: v1
-                  kind: LimitRange
-                  metadata:
-                    name: sandbox-limit-range
                   spec:
                     limits:
                       - default:

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1783,6 +1783,26 @@ components:
                   limits.memory: "20Gi"
                   secrets: "2"
                   requests.ephemeral-storage: "100Gi"
+              limit_range:
+                type: object
+                description: |-
+                  Limit Range for the sandbox
+                  This allows to set the default limit and request for pods
+                  see https://kubernetes.io/docs/concepts/policy/limit-range/
+                example:
+                  apiVersion: v1
+                  kind: LimitRange
+                  metadata:
+                    name: sandbox-limit-range
+                  spec:
+                    limits:
+                      - default:
+                          cpu: "1"
+                          memory: 2Gi
+                        defaultRequest:
+                          cpu: "0.5"
+                          memory: 1Gi
+                        type: Container
         annotations:
           $ref: "#/components/schemas/Annotations"
       example:

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1613,6 +1613,26 @@ paths:
                   $ref: "#/components/schemas/Annotations"
                 additional_vars:
                   type: object
+                limit_range:
+                  description: |-
+                    Limit Range for the sandbox
+                    This allows to set the default limit and request for pods
+                    see https://kubernetes.io/docs/concepts/policy/limit-range/
+                  type: object
+                  example:
+                    apiVersion: v1
+                    kind: LimitRange
+                    metadata:
+                      name: sandbox-limit-range
+                    spec:
+                      limits:
+                        - default:
+                            cpu: "1"
+                            memory: 2Gi
+                          defaultRequest:
+                            cpu: "0.5"
+                            memory: 1Gi
+                          type: Container
             example:
               strict_default_sandbox_quota: true
               quota_required: true
@@ -1632,6 +1652,20 @@ paths:
                 limits.memory: "20Gi"
                 secrets: "2"
                 requests.ephemeral-storage: "100Gi"
+              limit_range:
+                apiVersion: v1
+                kind: LimitRange
+                metadata:
+                  name: sandbox-limit-range
+                spec:
+                  limits:
+                    - default:
+                        cpu: "1"
+                        memory: 2Gi
+                      defaultRequest:
+                        cpu: "0.5"
+                        memory: 1Gi
+                      type: Container
       responses:
         '200':
           description: The OcpSharedClusterConfiguration is updated
@@ -2345,6 +2379,27 @@ components:
             If set to false, the sandbox quota will be created, depending on the value of
             quota_required, default_sandbox_quota and strict_default_sandbox_quota.
           default: true
+        limit_range:
+          type: object
+          description: |-
+            Limit Range for the sandbox
+            This allows to set the default limit and request for pods
+            see https://kubernetes.io/docs/concepts/policy/limit-range/
+          default:
+            apiVersion: v1
+            kind: LimitRange
+            metadata:
+              name: sandbox-limit-range
+            spec:
+              limits:
+                - default:
+                    cpu: "1"
+                    memory: 2Gi
+                  defaultRequest:
+                    cpu: "0.5"
+                    memory: 1Gi
+                  type: Container
+
       example:
         name: ocp-cluster-1
         api_url: https://api.ocp-cluster-1.com:6443

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -108,6 +108,7 @@ type ResourceRequest struct {
 	Annotations    models.Annotations `json:"annotations,omitempty"`
 	CloudSelector  models.Annotations `json:"cloud_selector,omitempty"`
 	Quota          *v1.ResourceList   `json:"quota,omitempty"`
+	LimitRange     *v1.LimitRange     `json:"limit_range,omitempty"`
 	RequestedQuota *v1.ResourceQuota  `json:"-"` // plumbing
 }
 
@@ -152,6 +153,11 @@ func (p *PlacementRequest) Bind(r *http.Request) error {
 					resourceRequest.CloudSelector[k] = "no"
 				}
 			}
+		}
+
+		if resourceRequest.LimitRange != nil {
+			// Automatically set the name of the limit range
+			resourceRequest.LimitRange.Name = "sandbox-limit-range"
 		}
 	}
 

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -188,6 +188,7 @@ type UpdateOcpSharedConfigurationRequest struct {
 	AdditionalVars            map[string]any      `json:"additional_vars,omitempty"`
 	MaxMemoryUsagePercentage  *float64            `json:"max_memory_usage_percentage,omitempty"`
 	MaxCpuUsagePercentage     *float64            `json:"max_cpu_usage_percentage,omitempty"`
+	LimitRange                *v1.LimitRange      `json:"limit_range,omitempty"`
 }
 
 func (j *UpdateOcpSharedConfigurationRequest) Bind(r *http.Request) error {

--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -71,6 +71,11 @@ type OcpSharedClusterConfiguration struct {
 	// By default it's true.
 	// TODO: change the default value to false
 	SkipQuota bool `json:"skip_quota"`
+
+	// Limit Range for the sandbox
+	// This allows to set the default limit and request for pods
+	// see https://kubernetes.io/docs/concepts/policy/limit-range/
+	LimitRange *v1.LimitRange `json:"limit_range,omitempty"`
 }
 
 type OcpSharedClusterConfigurations []OcpSharedClusterConfiguration
@@ -91,6 +96,7 @@ type OcpSandbox struct {
 	ClusterAdditionalVars             map[string]any    `json:"cluster_additional_vars,omitempty"`
 	ToCleanup                         bool              `json:"to_cleanup"`
 	Quota                             v1.ResourceList   `json:"quota,omitempty"`
+	LimitRange                        *v1.LimitRange    `json:"limit_range,omitempty"`
 }
 
 type OcpSandboxWithCreds struct {
@@ -152,6 +158,42 @@ func MakeOcpSharedClusterConfiguration() *OcpSharedClusterConfiguration {
 	p.StrictDefaultSandboxQuota = false
 	p.QuotaRequired = false
 	p.SkipQuota = true
+
+	// Default Limit Range for new OcpSharedClusterConfiguration
+	// ---
+	// apiVersion: v1
+	// kind: LimitRange
+	// metadata:
+	//   name: sandbox-limit-range
+	// spec:
+	//   limits:
+	//   - default:
+	//       cpu: "1"
+	//       memory: 2Gi
+	//     defaultRequest:
+	//       cpu: "0.5"
+	//       memory: 1Gi
+	//     type: Container
+	p.LimitRange = &v1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sandbox-limit-range",
+		},
+		Spec: v1.LimitRangeSpec{
+			Limits: []v1.LimitRangeItem{
+				{
+					Type: "Container",
+					Default: v1.ResourceList{
+						"cpu":    resource.MustParse("1"),
+						"memory": resource.MustParse("2Gi"),
+					},
+					DefaultRequest: v1.ResourceList{
+						"cpu":    resource.MustParse("0.5"),
+						"memory": resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+	}
 
 	return p
 }
@@ -229,8 +271,9 @@ func (p *OcpSharedClusterConfiguration) Save() error {
 			default_sandbox_quota,
 			strict_default_sandbox_quota,
 			quota_required,
-			skip_quota)
-			VALUES ($1, $2, $3, pgp_sym_encrypt($4::text, $5), pgp_sym_encrypt($6::text, $5), $7, $8, $9, $10, $11, $12, $13, $14, $15)
+			skip_quota,
+			limit_range)
+			VALUES ($1, $2, $3, pgp_sym_encrypt($4::text, $5), pgp_sym_encrypt($6::text, $5), $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 			RETURNING id`,
 		p.Name,
 		p.ApiUrl,
@@ -247,6 +290,7 @@ func (p *OcpSharedClusterConfiguration) Save() error {
 		p.StrictDefaultSandboxQuota,
 		p.QuotaRequired,
 		p.SkipQuota,
+		p.LimitRange,
 	).Scan(&p.ID); err != nil {
 		return err
 	}
@@ -275,7 +319,8 @@ func (p *OcpSharedClusterConfiguration) Update() error {
 			 default_sandbox_quota = $13,
 			 strict_default_sandbox_quota = $14,
 			 quota_required = $15,
-			 skip_quota = $16
+			 skip_quota = $16,
+			 limit_range = $17
 		 WHERE id = $10`,
 		p.Name,
 		p.ApiUrl,
@@ -293,6 +338,7 @@ func (p *OcpSharedClusterConfiguration) Update() error {
 		p.StrictDefaultSandboxQuota,
 		p.QuotaRequired,
 		p.SkipQuota,
+		p.LimitRange,
 	); err != nil {
 		return err
 	}
@@ -359,7 +405,8 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurationByName(name string)
 			default_sandbox_quota,
 			strict_default_sandbox_quota,
 			quota_required,
-			skip_quota
+			skip_quota,
+			limit_range
 		 FROM ocp_shared_cluster_configurations WHERE name = $2`,
 		p.VaultSecret, name,
 	)
@@ -383,6 +430,7 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurationByName(name string)
 		&cluster.StrictDefaultSandboxQuota,
 		&cluster.QuotaRequired,
 		&cluster.SkipQuota,
+		&cluster.LimitRange,
 	); err != nil {
 		return OcpSharedClusterConfiguration{}, err
 	}
@@ -415,7 +463,8 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurations() (OcpSharedClust
 			default_sandbox_quota,
 			strict_default_sandbox_quota,
 			quota_required,
-            skip_quota
+            skip_quota,
+			limit_range
 		 FROM ocp_shared_cluster_configurations`,
 		p.VaultSecret,
 	)
@@ -448,6 +497,7 @@ func (p *OcpSandboxProvider) GetOcpSharedClusterConfigurations() (OcpSharedClust
 			&cluster.StrictDefaultSandboxQuota,
 			&cluster.QuotaRequired,
 			&cluster.SkipQuota,
+			&cluster.LimitRange,
 		); err != nil {
 			return []OcpSharedClusterConfiguration{}, err
 		}
@@ -1119,6 +1169,26 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 				}
 				rnew.SetStatus("error")
 				return
+			}
+
+			// Create the limit range
+			if selectedCluster.LimitRange.Name != "" {
+				_, err = clientset.CoreV1().LimitRanges(namespaceName).Create(context.TODO(), selectedCluster.LimitRange, metav1.CreateOptions{})
+				if err != nil {
+					log.Logger.Error("Error creating OCP limit range", "error", err)
+					if err := clientset.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, metav1.DeleteOptions{}); err != nil {
+						log.Logger.Error("Error cleaning up the namespace", "error", err)
+					}
+					rnew.SetStatus("error")
+					return
+				}
+
+				rnew.LimitRange = selectedCluster.LimitRange
+				if err := rnew.Save(); err != nil {
+					log.Logger.Error("Error saving OCP account", "error", err)
+					rnew.SetStatus("error")
+					return
+				}
 			}
 		}
 

--- a/tests/001.hurl
+++ b/tests/001.hurl
@@ -25,6 +25,15 @@ jsonpath "$.access_token" isString
 jsonpath "$.access_token_exp" isString
 
 #################################################################################
+# Delete the reservation
+#################################################################################
+DELETE {{host}}/api/v1/reservations/summit
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 3
+HTTP 404
+
+#################################################################################
 # Create or update or a new reservation without the admin token
 #################################################################################
 

--- a/tests/005_limit_range.hurl
+++ b/tests/005_limit_range.hurl
@@ -199,11 +199,6 @@ Authorization: Bearer {{access_token}}
     {
       "kind": "OcpSandbox",
       "limit_range": {
-        "apiVersion": "v1",
-        "kind": "LimitRange",
-        "metadata": {
-          "name": "sandbox-limit-range"
-        },
         "spec": {
           "limits": [
             {

--- a/tests/005_limit_range.hurl
+++ b/tests/005_limit_range.hurl
@@ -181,3 +181,99 @@ Authorization: Bearer {{access_token}}
 [Options]
 retry: 40
 HTTP 404
+
+#################################################################################
+# Create a new placement specifying the limit range in the request
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 6
+HTTP 404
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "limit_range": {
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {
+          "name": "sandbox-limit-range"
+        },
+        "spec": {
+          "limits": [
+            {
+              "default": {
+                "cpu": "10",
+                "memory": "4Gi"
+              },
+              "defaultRequest": {
+                "cpu": "1",
+                "memory": "2Gi"
+              },
+              "type": "Container"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "OcpSandbox placement with limit range",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-foo"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+jsonpath "$.resources[0].limit_range.spec.limits" count == 1
+jsonpath "$.resources[0].limit_range.spec.limits[0].default.cpu" == "10"
+
+#################################################################################
+# Delete placement
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404

--- a/tests/005_limit_range.hurl
+++ b/tests/005_limit_range.hurl
@@ -1,0 +1,183 @@
+#################################################################################
+# Get an access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token}}
+HTTP 200
+[Captures]
+access_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Get an Admin access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token_admin}}
+HTTP 200
+[Captures]
+access_token_admin: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Update default quota of an OcpSharedClusterConfiguration
+#################################################################################
+
+DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 2
+HTTP 404
+
+POST {{host}}/api/v1/ocp-shared-cluster-configurations
+Authorization: Bearer {{access_token_admin}}
+{
+    "name": "ocp-cluster-test1",
+    "api_url": "https://api.ocp-cluster-1.com:6443",
+    "ingress_domain": "apps.ocp-cluster-1.com",
+    "kubeconfig": "apiVersion: v1 ...",
+    "skip_quota": true,
+    "annotations": {
+        "virt": "no",
+        "cloud": "ibm",
+        "purpose": "dev"
+    }
+}
+HTTP 201
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration created"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.limit_range.spec.limits" count == 1
+jsonpath "$.limit_range.spec.limits[0].default.cpu" == "1"
+jsonpath "$.limit_range.spec.limits[0].default.memory" == "2Gi"
+jsonpath "$.limit_range.spec.limits[0].defaultRequest.cpu" == "500m"
+jsonpath "$.limit_range.spec.limits[0].defaultRequest.memory" == "1Gi"
+
+PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/update
+Authorization: Bearer {{ access_token_admin }}
+{
+  "limit_range": {
+    "apiVersion": "v1",
+    "kind": "LimitRange",
+    "metadata": {
+      "name": "sandbox-limit-range"
+    },
+    "spec": {
+      "limits": [
+        {
+          "default": {
+            "cpu": "2",
+            "memory": "4Gi"
+          },
+          "defaultRequest": {
+            "cpu": "1",
+            "memory": "2Gi"
+          },
+          "type": "Container"
+        }
+      ]
+    }
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "OCP shared cluster configuration updated"
+
+GET {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+HTTP 200
+[Asserts]
+jsonpath "$.limit_range.spec.limits[0].default.cpu" == "2"
+jsonpath "$.limit_range.spec.limits[0].default.memory" == "4Gi"
+jsonpath "$.limit_range.spec.limits[0].defaultRequest.cpu" == "1"
+jsonpath "$.limit_range.spec.limits[0].defaultRequest.memory" == "2Gi"
+
+DELETE {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 2
+HTTP 404
+
+#################################################################################
+# Create a new placement
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 6
+HTTP 404
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox"
+    }
+  ],
+  "annotations": {
+    "tests": "Simple OcpSandbox placement for limit range test",
+    "guid": "testg",
+    "env_type": "ocp4-cluster-foo"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+jsonpath "$.resources[0].limit_range.spec.limits" count == 1
+jsonpath "$.resources[0].limit_range.spec.limits[0].default.cpu" == "1"
+
+#################################################################################
+# Delete placement
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404


### PR DESCRIPTION
On 4.14 we hit this bug https://github.com/kubevirt/containerized-data-importer/pull/3157 the container to copy disks, doesn't set the requests/limits https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/

Implement Limit range in the OcpSharedClusterConfiguration. Add a sensible default and the ability to update it.



Each new namespace created for a sandbox will have a limitrange:

```
[ec2-user@bastion ~]$ oc describe limitrange
Name:       sandbox-limit-range
Namespace:  sandbox-testg-16e9ff07-4e60-49f5-968b-c3df4a2292b5
Type        Resource  Min  Max  Default Request  Default Limit  Max Limit/Request Ratio
----        --------  ---  ---  ---------------  -------------  -----------------------
Container   cpu       -    -    500m             1              -
Container   memory    -    -    1Gi              2Gi            -
```


Those are the default values.
The values can be changed by reaching to the `PUT /api/v1/ocp-shared-cluster-configuration/update` endpoint

For example:

```
PUT {{host}}/api/v1/ocp-shared-cluster-configurations/ocp-cluster-test1/update
Authorization: Bearer {{ access_token_admin }}
{
  "limit_range": {
    "spec": {
      "limits": [
        {
          "default": {
            "cpu": "2",
            "memory": "4Gi"
          },
          "defaultRequest": {
            "cpu": "1",
            "memory": "2Gi"
          },
          "type": "Container"
        }
      ]
    }
  }
}
HTTP 200
[Asserts]
jsonpath "$.message" == "OCP shared cluster configuration updated"
```

It's also possible to overwrite this limit range in agnosticv, per catalog item:

```yaml
__meta__:
  sandboxes:
    - kind: OcpSandbox
      limit_range:
        spec:
          limits:
            - type: Container
              default:
                cpu: "1"
                memory: 2Gi
              defaultRequest:
                cpu: "0.5"
                memory: 1Gi

```