### PR TITLE
Conan performance improvements

### DIFF
--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -68,6 +68,9 @@ lock_timeout=${lock_timeout:-2}
 # Variable to manage output loglevel
 debug=false
 
+# Control weither to run the legacy aws-nuke or not, in addition to the active fork
+run_aws_nuke_legacy=false
+
 ##############
 
 export AWSCLI
@@ -92,6 +95,7 @@ export vault_file
 export workdir
 export sandbox_filter
 export debug
+export run_aws_nuke_legacy
 
 ORIG="$(cd "$(dirname "$0")" || exit; pwd)"
 

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -69,7 +69,7 @@ lock_timeout=${lock_timeout:-2}
 debug=false
 
 # Control weither to run the legacy aws-nuke or not, in addition to the active fork
-run_aws_nuke_legacy=false
+run_aws_nuke_legacy=${run_aws_nuke_legacy:-false}
 
 ##############
 

--- a/conan/conan.sh
+++ b/conan/conan.sh
@@ -66,7 +66,7 @@ lock_timeout=${lock_timeout:-2}
 
 
 # Variable to manage output loglevel
-debug=false
+debug=${debug:-false}
 
 # Control weither to run the legacy aws-nuke or not, in addition to the active fork
 run_aws_nuke_legacy=${run_aws_nuke_legacy:-false}

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -239,6 +239,7 @@ sandbox_reset() {
         -e kerberos_keytab="${kerberos_keytab:-}" \
         -e kerberos_user="${kerberos_user}" \
         -e kerberos_password="${kerberos_password:-}" \
+        -e run_aws_nuke_legacy="${run_aws_nuke_legacy:-false}" \
         reset_single.yml > "${logfile}"; then
         echo "$(date -uIs) ${sandbox} reset OK"
         end_time=$(date +%s)

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -246,6 +246,12 @@ sandbox_reset() {
         # Calculate the time it took
         echo "$(date -uIs) ${sandbox} reset took $((duration / 60))m$((duration % 60))s"
 
+        if [ "${debug}" = "true" ]; then
+            echo "$(date -uIs) =========BEGIN========== ${logfile}"
+            cat "${logfile}"
+            echo "$(date -uIs) =========END============ ${logfile}"
+        fi
+
         rm "${eventlog}"
     else
         end_time=$(date +%s)

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -246,6 +246,7 @@ sandbox_reset() {
         duration=$((end_time - start_time))
         # Calculate the time it took
         echo "$(date -uIs) ${sandbox} reset took $((duration / 60))m$((duration % 60))s"
+        echo "$(date -uIs) ${sandbox} $(grep -Eo 'Nuke complete: [^"]+' "${logfile}")"
 
         if [ "${debug}" = "true" ]; then
             echo "$(date -uIs) =========BEGIN========== ${logfile}"

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -120,7 +120,11 @@ EOM
 
         # check if max_retries is reached
         if [ "$(get_conan_cleanup_count "${sandbox}")" -ge "${max_retries}" ]; then
-            echo "$(date -uIs) ${sandbox} max_retries reached, skipping for now, will retry after 24h"
+            # print info only once.
+            if [ ! -e "/tmp/${sandbox}_max_retries" ]; then
+                echo "$(date -uIs) ${sandbox} max_retries reached, skipping for now, will retry after 24h"
+                touch "/tmp/${sandbox}_max_retries"
+            fi
             rm "${errlog}"
             return 1
         fi
@@ -138,7 +142,6 @@ EOM
             exit 1
         fi
     fi
-
 
     # If anything happens, unlock the sandbox
     trap "_on_exit" EXIT

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -122,32 +122,6 @@
         - set_fact:
             run_aws_nuke_again: true
 
-    # Target groups
-    - name: List all target groups
-      command: >-
-        {{ aws_cli }} --region "{{ _region }}"
-        vpc-lattice list-target-groups
-        --query 'items[*].arn'  --output json
-
-      register: r_target_groups
-      changed_when: false
-      failed_when: >-
-        r_target_groups.rc != 0
-        and 'Could not connect to the endpoint URL' not in r_target_groups.stderr
-
-    - when: >-
-        r_target_groups.rc == 0 and r_target_groups.stdout != ""
-      block:
-        - name: Delete all target groups
-          loop: "{{ r_target_groups.stdout | default('[]', true) | from_json | default([]) }}"
-          command: >-
-            {{ aws_cli }} --region "{{ _region }}"
-            vpc-lattice delete-target-group
-            --target-group-identifier {{ item | quote }}
-
-        - set_fact:
-            run_aws_nuke_again: true
-
     # FSx filesystem cleanup
     - name: List all fsx volumes
       command: >-

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -69,38 +69,6 @@
         - set_fact:
             run_aws_nuke_again: true
 
-    # EIP
-
-    - ec2_eip_info:
-      register: r_all_eips
-
-    - when: r_all_eips.addresses | length > 0
-      block:
-        # The following does not seem to work with aws profile
-        # Thus use the aws CLI instead.
-        # - name: Disassociate and release EIP
-        #   ec2_eip:
-        #     state: absent
-        #     release_on_disassociation: true
-        #     public_ip: "{{ _eip.public_ip }}"
-        #     profile: "{{ account_profile }}"
-        #   loop: "{{ r_all_eips.addresses }}"
-        #   loop_control:
-        #     loop_var: _eip
-
-        - name: Disassociate EIP
-          command: >-
-            {{ aws_cli }} ec2
-            --region "{{ _region }}"
-            disassociate-address
-            --public-ip "{{ _eip.public_ip }}"
-          loop: "{{ r_all_eips.addresses }}"
-          loop_control:
-            loop_var: _eip
-
-        - set_fact:
-            run_aws_nuke_again: true
-
     # Access Points
     - name: List all Access points
       command: >-

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -22,6 +22,10 @@
       debug:
         var: r_manual_cleanup
 
+    - when: r_manual_cleanup is changed
+      set_fact:
+        run_aws_nuke_again: true
+
     # Reject all VPC connections
 
     - name: Get all VPC endpoint connections
@@ -61,31 +65,6 @@
             name: "{{ _sg.group_name }}"
             description: "{{ _sg.description }}"
             vpc_id: "{{ _sg.vpc_id }}"
-
-        - set_fact:
-            run_aws_nuke_again: true
-
-    # Instance
-
-    - name: Get all instances
-      ec2_instance_info:
-      register: r_all_instances
-
-    - when: r_all_instances.instances | length > 0
-      block:
-        - name: Disable termination protection on all instances
-          command: >-
-            {{ aws_cli }} ec2
-            --region "{{ _region }}"
-            modify-instance-attribute
-            --instance-id {{ _instance.instance_id }}
-            --no-disable-api-termination
-          when:
-            - '"state" in _instance'
-            - _instance.state.name != "terminated"
-          loop: "{{ r_all_instances.instances }}"
-          loop_control:
-            loop_var: _instance
 
         - set_fact:
             run_aws_nuke_again: true

--- a/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -69,30 +69,6 @@
         - set_fact:
             run_aws_nuke_again: true
 
-    # RDS DB Instances
-
-    - name: Get all RDS DB instances
-      command: >-
-        {{ aws_cli }}
-        --region {{ _region | quote }}
-        rds describe-db-instances
-        --output json
-        --query 'DBInstances[*].DBInstanceIdentifier'
-      register: r_all_db_instances
-      changed_when: false
-
-    - name: Save list as fact
-      set_fact:
-        db_instances: "{{ r_all_db_instances.stdout | from_json | list }}"
-
-    - name: Disable termination protection on all DBInstances
-      loop: "{{ db_instances }}"
-      command: >-
-        {{ aws_cli }}
-        --region {{ _region | quote }}
-        rds modify-db-instance
-        --db-instance-identifier {{ item }}
-        --no-deletion-protection
     # EIP
 
     - ec2_eip_info:

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -64,7 +64,7 @@
       retries: "{{ aws_nuke_retries }}"
       until: _awsnuke is succeeded
       no_log: true
-      async: 1800
+      async: 3600
       poll: 30
       delay: 30
 
@@ -104,6 +104,7 @@
           retries: 0
           until: _awsnuke2 is succeeded
           no_log: true
+          # second time shouldn't take too long
           async: 1800
           poll: 30
           delay: 30

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -17,27 +17,6 @@
     _hostedzoneid: "{{ _route53zone.zone_id }}"
     aws_public_zone: "{{ account_name }}{{subdomain_base}}."
 
-# Get a new token as the current one may have timed out (1h)
-- include_tasks: assume.yml
-
-- loop: "{{ all_regions }}"
-  loop_control:
-    loop_var: _region
-  environment:
-    AWS_REGION: "{{ _region }}"
-    AWS_DEFAULT_REGION: "{{ _region }}"
-    AWS_ACCESS_KEY_ID: "{{ assumed_role.sts_creds.access_key }}"
-    AWS_SECRET_ACCESS_KEY: "{{ assumed_role.sts_creds.secret_key }}"
-    AWS_SESSION_TOKEN: "{{ assumed_role.sts_creds.session_token }}"
-  ignore_errors: true
-  name: Run files/manual_cleanup.py script
-  script: files/manual_cleanup.py
-  register: r_manual_cleanup
-  # timeout after 2 minutes
-  timeout: 120
-  changed_when: >-
-    'Changes were made' in r_manual_cleanup.stdout
-
 - tags: nuke
   when: nuke_sandbox | bool
   block:

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -67,6 +67,8 @@
       async: 3600
       poll: 30
       delay: 30
+      changed_when: >-
+        'No resource to delete.' not in _awsnuke.stdout_lines
 
     - debug:
         # stdout and stderr are really not human friendly. keep stdout_lines and stdin_lines
@@ -108,6 +110,8 @@
           async: 1800
           poll: 30
           delay: 30
+          changed_when: >-
+            'No resource to delete.' not in _awsnuke.stdout_lines
 
         - debug:
             var: >-

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -132,6 +132,8 @@
       ignore_errors: true
       retries: "{{ aws_nuke_legacy_retries | default(0) }}"
       until: _awsnuke_legacy is succeeded
+      changed_when: >-
+        'No resource to delete.' not in _awsnuke_legacy.stdout_lines
       no_log: true
       async: 1800
       poll: 30
@@ -157,3 +159,8 @@
       fail:
         msg: aws-nuke-legacy failed
       when: _awsnuke_legacy is failed
+
+    - name: Report aws-nuke-legacy deleted resource(s)
+      fail:
+        msg: aws-nuke-legacy deleted resource(s). That should be investigated and reported.
+      when: _awsnuke_legacy is changed

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -118,6 +118,7 @@
               | items2dict
 
     - name: Run aws-nuke legacy on sandbox account
+      when: run_aws_nuke_legacy | default(false) | bool
       # be on the safe side, run the official (unmaintained) binary
       command: >-
         {{ aws_nuke_legacy_binary_path }}
@@ -143,6 +144,7 @@
           | selectattr('key', 'ne', 'stdout')
           | selectattr('key', 'ne', 'stderr')
           | items2dict
+      when: run_aws_nuke_legacy | default(false) | bool
 
     - name: Report aws-nuke error
       fail:

--- a/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/playbooks/roles/infra-aws-sandbox/tasks/reset.yml
@@ -49,12 +49,10 @@
         src: "{{ role_path }}/templates/nuke-config-legacy.yml.j2"
         dest: "{{ output_dir }}/{{ account_name }}_nuke-config-legacy.yml"
 
-    - name: Run aws-nuke on sandbox account with minimal output
+    - name: Run aws-nuke on sandbox account
       command: >-
         {{ aws_nuke_binary_path }} nuke --profile {{ account_name }}
         -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
-        --quiet
-        --log-level error
         --no-dry-run
         --force
       args:
@@ -96,7 +94,6 @@
           command: >-
             {{ aws_nuke_binary_path }} nuke --profile {{ account_name }}
             -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
-            --quiet
             --no-dry-run
             --force
           args:


### PR DESCRIPTION
Before:   **35+ minutes** to cleanup a sandbox
After and without `aws-nuke-legacy`:  **~5 minutes**

* Throw an error if aws-nuke-legacy deletes resource(s)
* Add a flag to disable/enable aws-nuke legacy
   Once we're sure no resource is ever cleaned up by aws-nuke legacy after aws-nuke new fork, we can easily disable it.
* Add ansible log when debug is on
* Give aws-nuke up to 1h
* target groups cleanup is done in `manual_cleanup.py`, remove it from ansible tasks
* Disassociation of EIP is done in `manual_cleanup.py`, remove it from ansible tasks
* RDS: Disable deletion protection is done by aws-nuke, remove it from the ansible tasks
* Termination protection is done by aws-nuke, remove it from the ansible tasks
* Reduce noise in logs
* Print `aws-nuke` summary, including the number of resources nuked.
   ```
   reset_sandbox939.log:Nuke complete: 0 failed, 2495 skipped, 3 finished.                                                                                                                                                                      
   ```

* Do not run `manual_cleanup.py` first but only after running aws-nuke once.