### PR TITLE
Fix aws-nuke staling when there are a lot of S3Objects

### DIFF
--- a/Containerfile.conan
+++ b/Containerfile.conan
@@ -9,7 +9,7 @@ RUN make sandbox-list
 FROM registry.access.redhat.com/ubi8/ubi:latest
     MAINTAINER Guillaume Coré <gucore@redhat.com>
 
-ARG AWSNUKE_VERSION=v3.26.0
+ARG AWSNUKE_VERSION=v3.35.2
 ARG AWSNUKE_LEGACY_VERSION=v2.25.0
 ARG RUSH_VERSION=v0.5.4
 

--- a/conan/wipe_sandbox.sh
+++ b/conan/wipe_sandbox.sh
@@ -252,9 +252,9 @@ sandbox_reset() {
         echo "$(date -uIs) ${sandbox} $(grep -Eo 'Nuke complete: [^"]+' "${logfile}")"
 
         if [ "${debug}" = "true" ]; then
-            echo "$(date -uIs) =========BEGIN========== ${logfile}"
+            echo "$(date -uIs) =========BEGIN========== ${HOSTNAME} ${logfile}"
             cat "${logfile}"
-            echo "$(date -uIs) =========END============ ${logfile}"
+            echo "$(date -uIs) =========END============ ${HOSTNAME} ${logfile}"
         fi
 
         rm "${eventlog}"
@@ -265,9 +265,9 @@ sandbox_reset() {
         echo "$(date -uIs) ${sandbox} reset took $((duration / 60))m$((duration % 60))s"
 
         echo "$(date -uIs) ${sandbox} reset FAILED." >&2
-        echo "$(date -uIs) =========BEGIN========== ${logfile}" >&2
+        echo "$(date -uIs) =========BEGIN========== ${HOSTNAME} ${logfile}" >&2
         cat "${logfile}" >&2
-        echo "$(date -uIs) =========END============ ${logfile}" >&2
+        echo "$(date -uIs) =========END============ ${HOSTNAME} ${logfile}" >&2
         sandbox_increase_conan_cleanup_count "${sandbox}"
         echo "$(date -uIs) ${sandbox} cleanup count: $(get_conan_cleanup_count "${sandbox}")"
         sync

--- a/playbooks/roles/infra-aws-sandbox/files/manual_cleanup.py
+++ b/playbooks/roles/infra-aws-sandbox/files/manual_cleanup.py
@@ -21,6 +21,24 @@ clientlaticce = boto3.client('vpc-lattice')
 
 client = boto3.client('ec2')
 
+# Stop all instances to save costs
+
+try:
+    response = client.describe_instances()
+
+    for reservation in response['Reservations']:
+        for instance in reservation['Instances']:
+            if instance['State']['Name'] == 'running':
+                client.stop_instances(
+                    InstanceIds=[
+                        instance['InstanceId']
+                    ]
+                )
+                print("Stopping instance: " + instance['InstanceId'])
+                changed = True
+except botocore.exceptions.ClientError as e:
+    print(e)
+
 try:
     response = client.describe_vpcs()
 

--- a/playbooks/roles/infra-aws-sandbox/templates/nuke-config.yml.j2
+++ b/playbooks/roles/infra-aws-sandbox/templates/nuke-config.yml.j2
@@ -28,23 +28,34 @@ resource-types:
   excludes:
     # don't nuke OpenSearch Packages, see https://github.com/rebuy-de/aws-nuke/issues/1123
     - AmazonML
-    - Cloud9Environment
-    - CloudSearchDomain
-    - CodeStarProject
-    - FMSNotificationChannel
-    - FMSPolicy
-    - MachineLearningBranchPrediction
-    - MachineLearningDataSource
-    - MachineLearningEvaluation
-    - MachineLearningMLModel
-    - OSPackage
+    - Cloud9Environment # Deprecated service
+    - CloudSearchDomain # Deprecated service
+    - CodeStarConnection # Deprecated service
+    - CodeStarNotification # Deprecated service
+    - CodeStarProject # Deprecated service
+    - FMSNotificationChannel # Excluded because it's not available
+    - FMSPolicy # Excluded because it's not available
+    - MachineLearningBranchPrediction # Excluded due to ML being unavailable
+    - MachineLearningDataSource # Excluded due to ML being unavailable
+    - MachineLearningEvaluation # Excluded due to ML being unavailable
+    - MachineLearningMLModel # Excluded due to ML being unavailable
     - OpsWorksApp
-    - OpsWorksCMBackup
-    - OpsWorksCMServer
-    - OpsWorksCMServerState
-    - OpsWorksInstance
-    - OpsWorksLayer
-    - OpsWorksUserProfile
+    - OpsWorksApp # Deprecated service
+    - OpsWorksCMBackup # Deprecated service
+    - OpsWorksCMServer # Deprecated service
+    - OpsWorksCMServerState # Deprecated service
+    - OpsWorksInstance # Deprecated service
+    - OpsWorksLayer # Deprecated service
+    - OpsWorksUserProfile # Deprecated service
+    - RedshiftServerlessNamespace # Deprecated service
+    - RedshiftServerlessSnapshot # Deprecated service
+    - RedshiftServerlessWorkgroup # Deprecated service
+    - RoboMakerDeploymentJob # Deprecated Service
+    - RoboMakerFleet # Deprecated Service
+    - RoboMakerRobot # Deprecated Service
     - RoboMakerRobotApplication
     - RoboMakerSimulationApplication
     - RoboMakerSimulationJob
+    - S3Object # Excluded because S3 bucket removal handles removing all S3Objects
+    - ServiceCatalogTagOption # Excluded due to https://github.com/rebuy-de/aws-nuke/issues/515
+    - ServiceCatalogTagOptionPortfolioAttachment # Excluded due to https://github.com/rebuy-de/aws-nuke/issues/515


### PR DESCRIPTION
GPTEINFRA-12752

- `aws-nuke` stale: when the account to cleanup has a lot of S3objects, with current config aws-nuke loops and fails.
  => In the config, exclude S3Object entirely, because S3 bucket removal handles removing all S3Objects already.
- Cost savings:  in case of any aws-nuke failure, stop all EC2 instances to save costs
- bump aws-nuke to latest stable version v3.35.2