### PR TITLE
[WIP] [RFE} Adding affinity for clusters

### DIFF
--- a/cmd/sandbox-api/handlers.go
+++ b/cmd/sandbox-api/handlers.go
@@ -175,7 +175,7 @@ func (h *BaseHandler) CreatePlacementHandler(w http.ResponseWriter, r *http.Requ
 			}
 		case "OcpSandbox":
 			// Create the placement in OCP
-		  log.Logger.Info("Affinity", "label", request.AffinityLabel, "type", request.AffinityType)
+			log.Logger.Info("Affinity", "label", request.AffinityLabel, "type", request.AffinityType)
 			var async_request bool = request.AffinityLabel == "" && request.AffinityType != ""
 			account, err := h.OcpSandboxProvider.Request(
 				placementRequest.ServiceUuid,

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1796,6 +1796,13 @@ components:
                 minimum: 1
                 default: 1
                 example: 1
+              affinity_label:
+                type: string
+              affinity_type:
+                type: string
+                enum:
+                  - sandbox_cluster
+                  - affinity_cluster
               cloud_selector:
                 $ref: "#/components/schemas/Annotations"
               annotations:

--- a/internal/api/v1/v1.go
+++ b/internal/api/v1/v1.go
@@ -105,6 +105,8 @@ func (p *PlacementResponse) Render(w http.ResponseWriter, r *http.Request) error
 type ResourceRequest struct {
 	Kind           string             `json:"kind"`
 	Count          int                `json:"count"`
+	AffinityLabel  string             `json:"affinity_label,omitempty"`
+	AffinityType   string             `json:"affinity_type,omitempty"`
 	Annotations    models.Annotations `json:"annotations,omitempty"`
 	CloudSelector  models.Annotations `json:"cloud_selector,omitempty"`
 	Quota          *v1.ResourceList   `json:"quota,omitempty"`

--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -120,8 +120,8 @@ type OcpServiceAccount struct {
 type OcpSandboxes []OcpSandbox
 
 type MultipleOcpAccount struct {
-  AffinityLabel string `json:"affinity_label"`
-  Account OcpSandbox   `json:"account"`
+	AffinityLabel string     `json:"affinity_label"`
+	Account       OcpSandbox `json:"account"`
 }
 
 type TokenResponse struct {
@@ -801,8 +801,8 @@ func (a *OcpSandboxProvider) GetSchedulableClusters(cloud_selector map[string]st
 	// Get resource from 'ocp_shared_cluster_configurations' table
 	var err error
 	var rows pgx.Rows
-  log.Logger.Info("affinityCluster", "cluster", affinityCluster)
-  log.Logger.Info("affinityType", "type", affinityType)
+	log.Logger.Info("affinityCluster", "cluster", affinityCluster)
+	log.Logger.Info("affinityType", "type", affinityType)
 	if affinityCluster == "" {
 		rows, err = a.DbPool.Query(
 			context.Background(),
@@ -934,10 +934,10 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 	if _, exists := annotations["guid"]; !exists {
 		return OcpSandboxWithCreds{}, errors.New("guid not found in annotations")
 	}
-	if (multipleAccounts != nil) {
-		for _, maccount := range multipleAccounts { 
+	if multipleAccounts != nil {
+		for _, maccount := range multipleAccounts {
 			if maccount.AffinityLabel == affinityLabel {
-				affinityCluster = maccount.Account.OcpSharedClusterConfigurationName	
+				affinityCluster = maccount.Account.OcpSharedClusterConfigurationName
 			}
 		}
 	}
@@ -1534,9 +1534,9 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 			"cluster", rnew.OcpSharedClusterConfigurationName, "namespace", rnew.Namespace)
 	}
 	if asyncRequest {
-		go task();
+		go task()
 	} else {
-		task();
+		task()
 	}
 	//--------------------------------------------------
 


### PR DESCRIPTION
This approach uses two new parameters in the request:

- **affinity_label** to assign a label for a sandbox, to be used as a reference
- **affinity_type** with two possible options:
  - **sandbox_cluster**: it will use the sandbox with same label but without affinity_type to decide which cluster to be used
  - **affinity_cluster**: it will use affinity cluster from the sandbox with same label
  
  Example:
  
  ```{
  "service_uuid": "c1aaf117-c5ac-4bc3-bcd7-b4d4de16e9fe",
  "resources": [
    {
      "kind": "OcpSandbox",
      "count": 1,
      "affinity_label": "main",
      "cloud_selector": {
         "cloud": "cnv",
         "virt": "yes",
         "purpose": "dev",
         "hcp": "no"
      }
    },
    {
      "kind": "OcpSandbox",
      "count": 1,
      "affinity_label": "main",
      "affinity_type": "affinity_cluster",
      "cloud_selector": {
         "cloud": "cnv",
         "purpose": "dev"
      }
    }
  ],
  "annotations": {
    "guid": "13012025",
    "env_type": "ocp4-cluster",
    "namespace_suffix": "ocp4-cluster"
  }
}
```

If the first sanndbox  is hosted on **ocpvdev01**, the second sandbox it will search in the database a cluster with affinity to **ocpvdev01** (ocpvdev01-hcp01, ocpvdev01-hcp02)..

Replacing **affinity_cluster** with **sandbox_cluster**, both sandbox will be in the same cluster