### PR TITLE
Dont break in providerLoop ocp_sandbox.go

### DIFF
--- a/internal/models/ocp_sandbox.go
+++ b/internal/models/ocp_sandbox.go
@@ -1046,7 +1046,6 @@ func (a *OcpSandboxProvider) Request(serviceUuid string, cloud_selector map[stri
 			if clusterMemoryUsage < cluster.MaxMemoryUsagePercentage && clusterCpuUsage < cluster.MaxCpuUsagePercentage {
 				selectedCluster = cluster
 				log.Logger.Info("selectedCluster", "cluster", selectedCluster.Name)
-				break providerLoop
 			}
 		}
 


### PR DESCRIPTION
Currently we select the first cluster returned by SQL query, as we are breaking the loop instead loop all of them to decide the less used