### PR TITLE
create_sandbox.py: Add a test to ensure Vault value is correct

### DIFF
--- a/playbooks/sandbox_functions.py
+++ b/playbooks/sandbox_functions.py
@@ -49,3 +49,20 @@ def get_all_sandboxes(dynamodb, dynamodb_table):
         sandboxes = data
 
     return sandboxes
+
+def get_random_sandbox(dynamodb, dynamodb_table):
+    response = dynamodb.scan(
+        TableName=dynamodb_table,
+        ConsistentRead=True,
+        # limit to 1 item
+        Limit=1,
+    )
+
+    if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+        raise Exception("Failed to get items from dynamodb")
+
+    data = response['Items']
+    if len(data) == 0:
+        raise Exception("No items found in dynamodb")
+
+    return data[0]


### PR DESCRIPTION
Try to read one key with the passed vault secret. If it doesn't work, exit. That will prevent accidentally creating sandboxes with a vault different that the one currently in use for the 'target DB'