### PR TITLE
feat: add application_name and session_idle_timeout to PostgreSQL

### DIFF
--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -110,6 +110,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	pgConfig.MaxConnIdleTime = 5 * time.Minute // Close idle connections after 5 minutes
+	pgConfig.MaxConnLifetime = time.Hour       // Close connections after 1 hour
+	pgConfig.HealthCheckPeriod = 30 * time.Second // Check health every 30 seconds
+
 	// Get shortname from CLUSTER_DOMAIN and hostname from system
 	clusterDomain := os.Getenv("CLUSTER_DOMAIN")
 	shortname := "unknown"
@@ -127,9 +131,6 @@ func main() {
 
 	// Configure application_name in shortname-hostname format
 	pgConfig.ConnConfig.RuntimeParams["application_name"] = fmt.Sprintf("%s-%s", shortname, hostname)
-
-	// Set session idle timeout to 5 minutes (300000 milliseconds)
-	pgConfig.ConnConfig.RuntimeParams["session_idle_timeout"] = "300000"
 
 	dbPool, err := pgxpool.ConnectConfig(context.Background(), pgConfig)
 	if err != nil {

--- a/cmd/sandbox-api/main.go
+++ b/cmd/sandbox-api/main.go
@@ -104,7 +104,7 @@ func main() {
 	connStr := os.Getenv("DATABASE_URL")
 
 	// Add connection parameters
-	config, err := pgxpool.ParseConfig(connStr)
+	pgConfig, err := pgxpool.ParseConfig(connStr)
 	if err != nil {
 		log.Logger.Error("Error parsing connection string", "error", err)
 		os.Exit(1)
@@ -126,12 +126,12 @@ func main() {
 	}
 
 	// Configure application_name in shortname-hostname format
-	config.ConnConfig.RuntimeParams["application_name"] = fmt.Sprintf("%s-%s", shortname, hostname)
+	pgConfig.ConnConfig.RuntimeParams["application_name"] = fmt.Sprintf("%s-%s", shortname, hostname)
 
 	// Set session idle timeout to 5 minutes (300000 milliseconds)
-	config.ConnConfig.RuntimeParams["session_idle_timeout"] = "300000"
+	pgConfig.ConnConfig.RuntimeParams["session_idle_timeout"] = "300000"
 
-	dbPool, err := pgxpool.ConnectConfig(context.Background(), config)
+	dbPool, err := pgxpool.ConnectConfig(context.Background(), pgConfig)
 	if err != nil {
 		log.Logger.Error("Error opening database connection", "error", err)
 		os.Exit(1)

--- a/deploy/helm-api/templates/deployment.yaml
+++ b/deploy/helm-api/templates/deployment.yaml
@@ -88,3 +88,11 @@ spec:
             secretKeyRef:
               name: sandbox-api-aws-assumerole
               key: assumerole_aws_secret_access_key
+
+        ##########################################
+        # CLUSTER DOMAIN (OPTIONAL)
+        ##########################################
+        {{- if .Values.clusterDomain }}
+        - name: CLUSTER_DOMAIN
+          value: {{ .Values.clusterDomain }}
+        {{- end }}


### PR DESCRIPTION
- Add application_name in format <cluster_domain_shortname>-<hostname>i (pod name)
- Set session_idle_timeout to 5 minutes (300000ms)
- Add optional CLUSTER_DOMAIN env var for ArgoCD deployments

This change improves database connection monitoring and resource management by identifying application instances and managing idle connections. The CLUSTER_DOMAIN is only used when deploying with ArgoCD to properly identify the environment in the application_name.
