### PR TITLE
feat: Add console_url to OcpSandbox and auto-detect if not present

### DIFF
--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -2892,6 +2892,9 @@ components:
         api_url:
           type: string
           example: https://api.ocp-cluster-1.com:6443
+        console_url:
+          type: string
+          example: https://console-openshift-console.apps.ocp-cluster-1.com
         ingress_domain:
           type: string
           example: apps.ocp-cluster-1.com

--- a/tests/002_ocp.hurl
+++ b/tests/002_ocp.hurl
@@ -299,12 +299,16 @@ Authorization: Bearer {{access_token}}
 [Options]
 retry: 60
 HTTP 200
+[Captures]
+console_url: jsonpath "$.resources[0].console_url"
 [Asserts]
 jsonpath "$.service_uuid" == "{{uuid}}"
 jsonpath "$.status" == "success"
 jsonpath "$.resources" count == 3
 jsonpath "$.resources[0].status" == "success"
 jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
 jsonpath "$.resources[0].credentials" count >= 1
 jsonpath "$.resources[0].cluster_additional_vars.deployer" exists
 jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
@@ -318,6 +322,14 @@ jsonpath "$.resources[2].credentials" count >= 1
 jsonpath "$.resources[2].credentials[0].kind" == "ServiceAccount"
 jsonpath "$.resources[2].credentials[0].token" isString
 
+#################################################################################
+# Connect to the web console, should be 200 OK
+#################################################################################
+
+GET {{console_url}}
+HTTP 200
+[Asserts]
+body contains "Red Hat OpenShift"
 
 #################################################################################
 # Delete placement
@@ -428,6 +440,8 @@ jsonpath "$.status" == "success"
 jsonpath "$.resources" count == 1
 jsonpath "$.resources[0].status" == "success"
 jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
 jsonpath "$.resources[0].credentials" count >= 1
 jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
 jsonpath "$.resources[0].credentials[0].token" isString
@@ -541,6 +555,9 @@ jsonpath "$.resources" count == 3
 jsonpath "$.resources[0].status" == "success"
 jsonpath "$.resources[1].status" == "success"
 jsonpath "$.resources[2].status" == "success"
+jsonpath "$.resources[0].console_url" contains "https://"
+jsonpath "$.resources[1].console_url" contains "https://"
+jsonpath "$.resources[2].console_url" contains "https://"
 jsonpath "$.resources[?(@.annotations.namespace_suffix == 'dev')].namespace" contains "sandbox-testg-1-dev"
 jsonpath "$.resources[?(@.annotations.namespace_suffix == 'test')].namespace" contains "sandbox-testg-2-test"
 jsonpath "$.resources[?(@.annotations.namespace_suffix == 'prod')].namespace" contains "sandbox-testg-3-prod"

--- a/tests/011_keycloak.hurl
+++ b/tests/011_keycloak.hurl
@@ -74,6 +74,8 @@ jsonpath "$.resources[0].credentials" count >= 2
 jsonpath "$.resources[0].credentials[?(@.kind == 'ServiceAccount')].token" count == 1
 jsonpath "$.resources[0].credentials[?(@.kind == 'KeycloakUser')].username" count == 1
 jsonpath "$.resources[0].credentials[?(@.kind == 'KeycloakUser')].password" count == 1
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
 
 #################################################################################
 # Delete placement


### PR DESCRIPTION
This pull request introduces the `console_url` field to the OcpSandbox resource.

This change is necessary because the OpenShift console cannot always be forged downstream, and may be exposed on a different domain than the cluster's primary applications ingress domain. By explicitly providing the console_url, we ensure that users can reliably access the web console for their sandbox environment.

The implementation first checks if the `console_url` is defined in the `additionalVars` of the cluster configuration. If it's not present, it automatically detects the URL by querying the Kubernetes API for the console route within the openshift-console namespace.

This change also includes:

* Updates to the Swagger API documentation
* New assertions in the Hurl tests to validate the presence and format of the `console_url` in the API responses.
  * Test the console URL retruned, make sure it's returning a 200 OK
