### PR TITLE
Introduce end-to-end cluster validation suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,9 @@ run-air: cmd/sandbox-api/assets/swagger.yaml .dev.pgenv .dev.jwtauth_env
 
 rm-local-pg:
 	@podman kill $${POSTGRESQL_POD} || true
-	@podman rm $${POSTGRESQL_POD} || true
 	@rm -f .dev.pg_password .dev.pgenv .dev.tokens_env .dev.admin_token .dev.app_token || true
 
-run-local-pg: rm-local-pg .dev.pg_password
+run-local-pg: .dev.pg_password
 	@echo "Running local postgres..."
 	@podman run  --rm -p $${POSTGRESQL_PORT}:5432 --name $${POSTGRESQL_POD} -e POSTGRES_PASSWORD=$(shell cat .dev.pg_password) -d postgres:16-bullseye
 # See full list of parameters here:

--- a/tests/jenkins-run.sh
+++ b/tests/jenkins-run.sh
@@ -10,6 +10,10 @@ jobdir=$PWD
 # trap function
 _on_exit() {
     local exit_status=${1:-$?}
+
+    # Kill entire process group of the API
+    [ -n "${apipid}" ] &&  kill -- -$apipid
+
     rm -rf $tmpdir
     cd $jobdir
 
@@ -90,7 +94,8 @@ set -o pipefail
 export PORT
 
 echo "Running sandbox API on port $PORT"
-make run-api &> $apilog &
+setsid make run-api &> $apilog &
+apipid=$!
 
 # Wait for the API to come up
 retries=0

--- a/tests/validation/001.hurl
+++ b/tests/validation/001.hurl
@@ -1,0 +1,458 @@
+#################################################################################
+# Get an access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token}}
+HTTP 200
+[Captures]
+access_token: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Get an Admin access token using the login token
+#################################################################################
+
+GET {{host}}/api/v1/login
+Authorization: Bearer {{login_token_admin}}
+HTTP 200
+[Captures]
+access_token_admin: jsonpath "$.access_token"
+[Asserts]
+jsonpath "$.access_token" isString
+jsonpath "$.access_token_exp" isString
+
+#################################################################################
+# Ensure placement doesn't exist
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 404
+
+#################################################################################
+# Create a new placement with a multiple Ocp
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{ cluster }}"
+      }
+    },
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{ cluster }}"
+      }
+    },
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{ cluster }}"
+      }
+    }
+  ],
+  "annotations": {
+    "test": "placement with multiple OpenShift namespace",
+    "guid": "{{guid}}",
+    "env_type": "test"
+  }
+}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 3
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 60
+HTTP 200
+[Captures]
+console_url: jsonpath "$.resources[0].console_url"
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 3
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].cluster_additional_vars.deployer" exists
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+jsonpath "$.resources[1].status" == "success"
+jsonpath "$.resources[1].credentials" count >= 1
+jsonpath "$.resources[1].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[1].credentials[0].token" isString
+jsonpath "$.resources[2].status" == "success"
+jsonpath "$.resources[2].credentials" count >= 1
+jsonpath "$.resources[2].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[2].credentials[0].token" isString
+
+#################################################################################
+# Connect to the web console, should be 200 OK
+#################################################################################
+
+GET {{console_url}}
+HTTP 200
+[Asserts]
+body contains "Red Hat OpenShift"
+
+#################################################################################
+# Delete placement
+#################################################################################
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Create a new placement
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{ cluster }}"
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "Simple OcpSandbox placement",
+    "guid": "{{ guid }}",
+    "env_type": "validate-cluster"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
+jsonpath "$.resources[0].credentials" count >= 1
+jsonpath "$.resources[0].credentials[0].kind" == "ServiceAccount"
+jsonpath "$.resources[0].credentials[0].token" isString
+
+#################################################################################
+# Delete placement
+#################################################################################
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Create a new placement With 3 sandboxes with namespace suffix
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "dev"}},
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "test"}},
+    {"kind": "OcpSandbox", "annotations": {"namespace_suffix": "prod"}}
+  ],
+  "annotations": {
+    "test": "Placement with 3 sandboxes with namespace suffix",
+    "guid": "{{ guid }}",
+    "env_type": "cluster-validation"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 3
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 3
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[1].status" == "success"
+jsonpath "$.resources[2].status" == "success"
+jsonpath "$.resources[0].console_url" contains "https://"
+jsonpath "$.resources[1].console_url" contains "https://"
+jsonpath "$.resources[2].console_url" contains "https://"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'dev')].namespace" contains "sandbox-{{ guid }}-1-dev"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'test')].namespace" contains "sandbox-{{ guid }}-2-test"
+jsonpath "$.resources[?(@.annotations.namespace_suffix == 'prod')].namespace" contains "sandbox-{{ guid }}-3-prod"
+
+#################################################################################
+# Delete placement
+#################################################################################
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "deleting"
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Create a placement and specify a quota
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "quota": {
+        "requests.memory": "10Gi",
+        "requests.cpu": "40"
+      },
+      "cloud_selector": {
+        "name": "{{ cluster }}"
+      },
+      "limit_range": {
+        "spec": {
+          "limits": [
+            {
+              "default": {
+                "cpu": "10",
+                "memory": "4Gi"
+              },
+              "defaultRequest": {
+                "cpu": "1",
+                "memory": "2Gi"
+              },
+              "type": "Container"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "OcpSandbox placement with a Quota and limit range",
+    "guid": "{{ guid }}",
+    "env_type": "validate-cluster"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+# Wait until the placement is succesfull and resources are ready
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Captures]
+testcluster: jsonpath "$.resources[0].ocp_cluster"
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].quota['requests.memory']" == "10Gi"
+jsonpath "$.resources[0].quota['requests.cpu']" == "40"
+jsonpath "$.resources[0].limit_range.spec.limits" count == 1
+jsonpath "$.resources[0].limit_range.spec.limits[0].default.cpu" == "10"
+
+# Delete placement
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Create a new placement, with keycloak enabled
+#################################################################################
+
+POST {{host}}/api/v1/placements
+Authorization: Bearer {{access_token}}
+{
+  "service_uuid": "{{uuid}}",
+  "resources": [
+    {
+      "kind": "OcpSandbox",
+      "cloud_selector": {
+        "name": "{{ cluster }}",
+        "keycloak": "true"
+      }
+    }
+  ],
+  "annotations": {
+    "tests": "Simple OcpSandbox placement with keycloak user",
+    "guid": "{{ guid }}",
+    "env_type": "validate-cluster"
+  }
+}
+HTTP 200
+[Captures]
+sandbox_name: jsonpath "$.Placement.resources[0].name"
+[Asserts]
+jsonpath "$.message" == "Placement Created"
+jsonpath "$.Placement.service_uuid" == "{{uuid}}"
+jsonpath "$.Placement.resources" count == 1
+jsonpath "$.Placement.resources[0].status" == "initializing"
+
+#################################################################################
+# Wait until the placement is succesfull and resources are ready
+#################################################################################
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 200
+[Asserts]
+jsonpath "$.service_uuid" == "{{uuid}}"
+jsonpath "$.status" == "success"
+jsonpath "$.resources" count == 1
+jsonpath "$.resources[0].status" == "success"
+jsonpath "$.resources[0].ingress_domain" split "." count > 2
+jsonpath "$.resources[0].credentials" count >= 2
+jsonpath "$.resources[0].credentials[?(@.kind == 'ServiceAccount')].token" count == 1
+jsonpath "$.resources[0].credentials[?(@.kind == 'KeycloakUser')].username" count == 1
+jsonpath "$.resources[0].credentials[?(@.kind == 'KeycloakUser')].password" count == 1
+jsonpath "$.resources[0].console_url" isString
+jsonpath "$.resources[0].console_url" contains "https://"
+
+#################################################################################
+# Delete placement
+#################################################################################
+
+DELETE {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+HTTP 202
+
+GET {{host}}/api/v1/placements/{{uuid}}
+Authorization: Bearer {{access_token}}
+[Options]
+retry: 40
+HTTP 404
+
+#################################################################################
+# Run status request for all shared clusters
+#################################################################################
+
+POST {{host}}/api/v1/ocp-shared-clusters/status
+Authorization: Bearer {{access_token_admin}}
+HTTP 202
+[Captures]
+status_request_id: jsonpath "$.request_id"
+[Asserts]
+jsonpath "$.request_id" isString
+jsonpath "$.status" == "initializing"
+jsonpath "$.message" == "Status Request successfully created"
+
+#################################################################################
+# Poll for the final status, expecting it to eventually succeed
+#################################################################################
+GET {{host}}/api/v1/ocp-shared-clusters/status
+Authorization: Bearer {{access_token_admin}}
+[Options]
+retry: 20
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "success"
+jsonpath "$.request_id" == "{{status_request_id}}"
+jsonpath "$.created_at" isString
+jsonpath "$.completed_at" isString
+jsonpath "$.body.clusters" isCollection
+jsonpath "$.body.clusters['{{ cluster }}'].cluster_name" isString
+jsonpath "$.body.clusters['{{ cluster }}'].ocp_version" isString
+jsonpath "$.body.clusters['{{ cluster }}'].configuration.name" isString
+jsonpath "$.body.clusters['{{ cluster }}'].configuration.kubeconfig" not exists
+jsonpath "$.body.clusters['{{ cluster }}'].configuration.token" not exists

--- a/tests/validation/Jenkinsfile
+++ b/tests/validation/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+
+    parameters {
+        string(name: 'cluster', defaultValue: 'all', description: 'cluster to validate')
+        string(name: 'sandbox-api-configs-ref', defaultValue: 'main', description: 'sandbox-api-configs branch or tag to use')
+    }
+
+    stages {
+        stage('Test') {
+            steps {
+                // Load the private repo git@github.com:rhpds/sandbox-api-configs.git
+
+                dir('sandbox-api-configs') {
+                    git branch: "${params['sandbox-api-configs-ref']}",
+                        credentialsId: 'ssh-key-ocp-shared-clusters-config',
+                        url: 'git@github.com:rhpds/sandbox-api-configs.git'
+                }
+
+
+                // Use  credential sandbox-functional-tests-dev-creds as a file to load the credentials
+                withCredentials([
+                    file(credentialsId: 'sandbox-functional-tests-dev-creds', variable: 'CREDENTIALS_FILE'),
+                    string(credentialsId: 'bw-ocp-shared-clusters-config-token', variable: 'BWS_ACCESS_TOKEN'),
+                    string(credentialsId: 'bw-ocp-shared-clusters-config-project-id', variable: 'BWS_PROJECT_ID'),
+                ]) {
+                    sh "tests/validation/validate-cluster.sh '${params.cluster}'"
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // This block will run regardless of success, failure, or abort
+            archiveArtifacts artifacts: 'api.log.gz'
+            archiveArtifacts artifacts: 'db_dump.sql.gz'
+            script {
+                def artifactUrlAPI = "${env.BUILD_URL}artifact/api.log.gz"
+                def artifactUrlDB = "${env.BUILD_URL}artifact/db_dump.sql.gz"
+
+                echo "API logs: ${artifactUrlAPI}"
+                echo "DB Dump: ${artifactUrlDB}"
+            }
+        }
+    }
+}

--- a/tests/validation/validate-cluster.sh
+++ b/tests/validation/validate-cluster.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+[ -e "${CREDENTIALS_FILE}" ] && source "${CREDENTIALS_FILE}"
+
+tmpdir=$(mktemp -d)
+apilog=$PWD/api.log
+dbdump=$PWD/db_dump.sql
+jobdir=$PWD
+
+# trap function
+_on_exit() {
+    local exit_status=${1:-$?}
+
+    # Kill entire process group of the API
+    [ -n "${apipid}" ] &&  kill -- -$apipid
+
+    rm -rf $tmpdir
+    cd $jobdir
+
+    (. ./.dev.pgenv ;
+     podman run --rm \
+         --net=host \
+         -v $(pwd):/backup:z \
+         postgres:16-bullseye \
+         pg_dump "${DATABASE_URL}" -f /backup/db_dump.sql
+    )
+    gzip -f $dbdump
+    gzip -f $apilog
+
+    make clean
+    exit $exit_status
+}
+
+trap "_on_exit" EXIT
+
+
+set -e -o pipefail
+unset DBUS_SESSION_BUS_ADDRESS
+
+clustername=$1
+if [ -z "$clustername" ]; then
+    echo "Usage: $0 <cluster>"
+    echo "Example: $0 ocpvdev01"
+    echo "use 'all' to run all clusters"
+    exit 1
+fi
+
+# Ensure binaries are installed
+mandatory_commands=(jq podman)
+
+for cmd in "${mandatory_commands[@]}"; do
+    if ! command -v $cmd &> /dev/null; then
+        echo "$cmd could not be found"
+        exit 1
+    fi
+done
+
+# Pull needed images
+podman pull --quiet quay.io/rhpds/sandbox-admin:latest
+podman pull --quiet docker.io/library/postgres:16-bullseye
+podman pull --quiet docker.io/bitwarden/bws:0.5.0
+
+# Run the local postgresql instance
+set +o pipefail
+POSTGRESQL_PORT=$(comm -23 <(seq 49152 65535) <(ss -tan | awk '{print $4}' | cut -d':' -f2 | grep "[0-9]\{1,5\}" | sort | uniq)  | shuf  | head -n 1 )
+if [ -z "$POSTGRESQL_PORT" ]; then
+    echo "No free port found"
+    exit 1
+fi
+set -o pipefail
+
+export POSTGRESQL_PORT
+POSTGRESQL_POD=localpg$$
+export POSTGRESQL_POD
+make run-local-pg
+
+# DB migrations
+sleep 2
+make migrate
+
+# Generate admin and app tokens
+make tokens
+
+# Run the API in background
+# Select a free port
+#PORT=54379
+set +o pipefail
+PORT=$(comm -23 <(seq 49152 65535) <(ss -tan | awk '{print $4}' | cut -d':' -f2 | grep "[0-9]\{1,5\}" | sort | uniq)  | shuf  | head -n 1 )
+if [ -z "$PORT" ]; then
+    echo "No free port found"
+    exit 1
+fi
+set -o pipefail
+export PORT
+
+echo "Running sandbox API on port $PORT"
+setsid make run-api &> $apilog &
+apipid=$!
+
+# Wait for the API to come up
+retries=0
+echo -n "Waiting for API to come up"
+while true; do
+    if [ $retries -gt 20 ]; then
+        echo "API not coming up"
+        exit 1
+    fi
+    if  [ "$(curl http://localhost:$PORT/ping -s)" == "." ]; then
+        break
+    fi
+
+    sleep 1
+    echo -n .
+    sync
+    retries=$((retries + 1))
+done
+echo
+
+source .dev.tokens_env
+
+uuid=$(uuidgen -r)
+guid=tt-$(echo $uuid | tr -dc 'a-z0-9' | head -c 4)
+export uuid
+export guid
+
+load_cluster_conf() {
+    local payload=$1
+    echo "Reading file $payload"
+    sleep 1
+    if [[ $payload =~ create.json$ ]]; then
+        cluster=$(cat $payload | jq -r ".name")
+    elif [[ $payload =~ update.json$ ]]; then
+        # take the name from the file name
+        cluster=$(basename $payload | sed 's/\.update\.json$//')
+    fi
+    [ -z "$cluster" ] && echo "Cluster name not found in $payload" && exit 1
+    payload2=$tmpdir/$(basename $payload)
+    token=$(podman run --rm \
+            -e BWS_ACCESS_TOKEN=$BWS_ACCESS_TOKEN \
+            -e PROJECT_ID=$BWS_PROJECT_ID \
+            --security-opt seccomp=unconfined \
+            bitwarden/bws:0.5.0 secret list  $BWS_PROJECT_ID \
+            | KEYVALUE="${cluster}.token" jq -r '.[] | select(.key==env.KEYVALUE) | .value')
+
+    jq  --arg token $token '(.token = $token)'  < "$payload" > "$payload2"
+
+    # In bash, files in a * are sorted alphabetically by default
+    # so a create will always happen before an update.
+    if [[ $payload =~ create.json$ ]]; then
+        echo "Creating cluster $cluster"
+        hurl --variable login_token_admin=$admintoken \
+            --file-root $tmpdir \
+            --variable host=http://localhost:$PORT \
+            --variable ocp_cluster_def=$payload2 \
+            ./tools/ocp_shared_cluster_configuration_create.hurl
+    elif [[ $payload =~ update.json$ ]]; then
+        echo "Updating cluster $cluster"
+        hurl --variable login_token_admin=$admintoken \
+            --file-root $tmpdir \
+            --variable host=http://localhost:$PORT \
+            --variable payload=$payload2 \
+            --variable cluster=$cluster \
+            ./tools/ocp_shared_cluster_configuration_update.hurl
+    fi
+}
+
+# Install the cluster configuration
+if [ "${clustername}" = "all" ]; then
+    # Find all clusternames
+    clusters=$(ls sandbox-api-configs/ocp-shared-cluster-configurations | grep -oE '^[^\.]+' | sort -u)
+
+    for payload in sandbox-api-configs/ocp-shared-cluster-configurations/*.json; do
+        load_cluster_conf $payload
+    done
+else
+    found=false
+    for payload in sandbox-api-configs/ocp-shared-cluster-configurations/$clustername.*.json; do
+        load_cluster_conf $payload
+        found=true
+    done
+
+    if [ "$found" = false ]; then
+        echo "No cluster configuration found for $clustername"
+        exit 1
+    fi
+    clusters="$clustername"
+fi
+
+cd tests/
+
+for cluster in $clusters; do
+    echo "Running tests for cluster $cluster"
+    hurl --test \
+        --variable login_token=$apptoken \
+        --variable login_token_admin=$admintoken \
+        --variable host=http://localhost:$PORT \
+        --variable cluster=$cluster \
+        --variable uuid=$uuid \
+        --variable guid=$guid \
+        --jobs 1 \
+        validation/*.hurl
+done


### PR DESCRIPTION
This commit introduces a validation framework for the sandbox API, designed to run from laptop or in jenkins.

It's orchestrated by `tests/validation/validate-cluster.sh`.

This script automates the entire testing lifecycle:
-   Pulls required container images (postgres, bws).
-   Starts a local PostgreSQL database and runs migrations.
-   Starts the sandbox API on a random available port.
-   Dynamically loads cluster configurations from the `sandbox-api-configs`
    repository.
-   Fetches cluster secrets from Bitwarden using `bws` and injects them
    into the configuration.
-   Registers the clusters with the running API instance.
-   Executes a suite of Hurl tests (`tests/validation/001.hurl`) that
    validate key API functionality, including placement creation with
    various options (multi-resource, quotas, Keycloak) and admin
    endpoints.
-   cleanup on exit, archiving API logs and a database dump.

A `Jenkinsfile` is added to integrate this test suite into a CI/CD pipeline, managing credentials and test parameters.

The existing `tests/jenkins-run.sh` script is also improved to use `setsid` when running the API. This ensures the entire process group can be terminated, preventing orphaned processes when running locally. (Jenkins usually cleans up processes properly)